### PR TITLE
[Setting] #2 - 푸시 알림 및 소셜로그인 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@
  # End of https://www.toptal.com/developers/gitignore/api/xcode,macos,swift
 
 Smeem-iOS/Smeem-iOS.xcodeproj/project.xcworkspace/xcuserdata/hwangchanmi.xcuserdatad/
+
+*.xcconfig

--- a/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
+++ b/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		4A0E8D5429F8346600E0FC23 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 4A0E8D5329F8346600E0FC23 /* FirebaseAnalyticsWithoutAdIdSupport */; };
 		4A0E8D5629F8346600E0FC23 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 4A0E8D5529F8346600E0FC23 /* FirebaseMessaging */; };
+		4A0E8D5829F8362E00E0FC23 /* AuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E8D5729F8362E00E0FC23 /* AuthViewController.swift */; };
+		4A0E8D5B29F8399700E0FC23 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4A0E8D5A29F8399700E0FC23 /* SnapKit */; };
 		4A8FFA5029C9E1FD00FB76C0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8FFA4F29C9E1FD00FB76C0 /* AppDelegate.swift */; };
 		4A8FFA5229C9E1FD00FB76C0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8FFA5129C9E1FD00FB76C0 /* SceneDelegate.swift */; };
 		4A8FFA5429C9E1FD00FB76C0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8FFA5329C9E1FD00FB76C0 /* ViewController.swift */; };
@@ -19,6 +21,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4A0E8D5729F8362E00E0FC23 /* AuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewController.swift; sourceTree = "<group>"; };
 		4A4E21EE29D9B02500BF8747 /* Smeem-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Smeem-iOS.entitlements"; sourceTree = "<group>"; };
 		4A8FFA4C29C9E1FD00FB76C0 /* Smeem-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Smeem-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A8FFA4F29C9E1FD00FB76C0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -36,6 +39,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4A0E8D5B29F8399700E0FC23 /* SnapKit in Frameworks */,
 				4A0E8D5629F8346600E0FC23 /* FirebaseMessaging in Frameworks */,
 				4A0E8D5429F8346600E0FC23 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
 			);
@@ -72,6 +76,7 @@
 				4A8FFA5829C9E1FE00FB76C0 /* Assets.xcassets */,
 				4A8FFA5A29C9E1FE00FB76C0 /* LaunchScreen.storyboard */,
 				4A8FFA5D29C9E1FE00FB76C0 /* Info.plist */,
+				4A0E8D5729F8362E00E0FC23 /* AuthViewController.swift */,
 			);
 			path = "Smeem-iOS";
 			sourceTree = "<group>";
@@ -95,6 +100,7 @@
 			packageProductDependencies = (
 				4A0E8D5329F8346600E0FC23 /* FirebaseAnalyticsWithoutAdIdSupport */,
 				4A0E8D5529F8346600E0FC23 /* FirebaseMessaging */,
+				4A0E8D5A29F8399700E0FC23 /* SnapKit */,
 			);
 			productName = "Smeem-iOS";
 			productReference = 4A8FFA4C29C9E1FD00FB76C0 /* Smeem-iOS.app */;
@@ -126,6 +132,7 @@
 			mainGroup = 4A8FFA4329C9E1FD00FB76C0;
 			packageReferences = (
 				4A0E8D5229F8346600E0FC23 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				4A0E8D5929F8399700E0FC23 /* XCRemoteSwiftPackageReference "SnapKit" */,
 			);
 			productRefGroup = 4A8FFA4D29C9E1FD00FB76C0 /* Products */;
 			projectDirPath = "";
@@ -156,6 +163,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4A8FFA5429C9E1FD00FB76C0 /* ViewController.swift in Sources */,
+				4A0E8D5829F8362E00E0FC23 /* AuthViewController.swift in Sources */,
 				4A8FFA5029C9E1FD00FB76C0 /* AppDelegate.swift in Sources */,
 				4A8FFA5229C9E1FD00FB76C0 /* SceneDelegate.swift in Sources */,
 			);

--- a/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
+++ b/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		4A0E8D5629F8346600E0FC23 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 4A0E8D5529F8346600E0FC23 /* FirebaseMessaging */; };
 		4A0E8D5829F8362E00E0FC23 /* AuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E8D5729F8362E00E0FC23 /* AuthViewController.swift */; };
 		4A0E8D5B29F8399700E0FC23 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4A0E8D5A29F8399700E0FC23 /* SnapKit */; };
+		4A47164D29F8EB2600CBE9C8 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 4A47164C29F8EB2600CBE9C8 /* KakaoSDKUser */; };
+		4A47164F29F907FE00CBE9C8 /* Shared.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A47164E29F907FE00CBE9C8 /* Shared.xcconfig */; };
 		4A8FFA5029C9E1FD00FB76C0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8FFA4F29C9E1FD00FB76C0 /* AppDelegate.swift */; };
 		4A8FFA5229C9E1FD00FB76C0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8FFA5129C9E1FD00FB76C0 /* SceneDelegate.swift */; };
 		4A8FFA5429C9E1FD00FB76C0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8FFA5329C9E1FD00FB76C0 /* ViewController.swift */; };
@@ -22,6 +24,7 @@
 
 /* Begin PBXFileReference section */
 		4A0E8D5729F8362E00E0FC23 /* AuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewController.swift; sourceTree = "<group>"; };
+		4A47164E29F907FE00CBE9C8 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
 		4A4E21EE29D9B02500BF8747 /* Smeem-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Smeem-iOS.entitlements"; sourceTree = "<group>"; };
 		4A8FFA4C29C9E1FD00FB76C0 /* Smeem-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Smeem-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A8FFA4F29C9E1FD00FB76C0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -39,6 +42,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4A47164D29F8EB2600CBE9C8 /* KakaoSDKUser in Frameworks */,
 				4A0E8D5B29F8399700E0FC23 /* SnapKit in Frameworks */,
 				4A0E8D5629F8346600E0FC23 /* FirebaseMessaging in Frameworks */,
 				4A0E8D5429F8346600E0FC23 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
@@ -51,6 +55,7 @@
 		4A8FFA4329C9E1FD00FB76C0 = {
 			isa = PBXGroup;
 			children = (
+				4A47164E29F907FE00CBE9C8 /* Shared.xcconfig */,
 				4A8FFA4E29C9E1FD00FB76C0 /* Smeem-iOS */,
 				4A8FFA4D29C9E1FD00FB76C0 /* Products */,
 			);
@@ -101,6 +106,7 @@
 				4A0E8D5329F8346600E0FC23 /* FirebaseAnalyticsWithoutAdIdSupport */,
 				4A0E8D5529F8346600E0FC23 /* FirebaseMessaging */,
 				4A0E8D5A29F8399700E0FC23 /* SnapKit */,
+				4A47164C29F8EB2600CBE9C8 /* KakaoSDKUser */,
 			);
 			productName = "Smeem-iOS";
 			productReference = 4A8FFA4C29C9E1FD00FB76C0 /* Smeem-iOS.app */;
@@ -113,6 +119,9 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
+				KnownAssetTags = (
+					New,
+				);
 				LastSwiftUpdateCheck = 1420;
 				LastUpgradeCheck = 1420;
 				TargetAttributes = {
@@ -133,6 +142,7 @@
 			packageReferences = (
 				4A0E8D5229F8346600E0FC23 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				4A0E8D5929F8399700E0FC23 /* XCRemoteSwiftPackageReference "SnapKit" */,
+				4A47164B29F8EB2600CBE9C8 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
 			productRefGroup = 4A8FFA4D29C9E1FD00FB76C0 /* Products */;
 			projectDirPath = "";
@@ -149,6 +159,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4A8FFA5C29C9E1FE00FB76C0 /* LaunchScreen.storyboard in Resources */,
+				4A47164F29F907FE00CBE9C8 /* Shared.xcconfig in Resources */,
 				4AC9489829ED800800489C2B /* GoogleService-Info.plist in Resources */,
 				4A8FFA5929C9E1FE00FB76C0 /* Assets.xcassets in Resources */,
 				4A8FFA5729C9E1FD00FB76C0 /* Main.storyboard in Resources */,
@@ -307,6 +318,7 @@
 		};
 		4A8FFA6129C9E1FE00FB76C0 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4A47164E29F907FE00CBE9C8 /* Shared.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -341,6 +353,7 @@
 		};
 		4A8FFA6229C9E1FE00FB76C0 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4A47164E29F907FE00CBE9C8 /* Shared.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -405,6 +418,22 @@
 				kind = branch;
 			};
 		};
+		4A0E8D5929F8399700E0FC23 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SnapKit/SnapKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
+		4A47164B29F8EB2600CBE9C8 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -417,6 +446,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4A0E8D5229F8346600E0FC23 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseMessaging;
+		};
+		4A0E8D5A29F8399700E0FC23 /* SnapKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4A0E8D5929F8399700E0FC23 /* XCRemoteSwiftPackageReference "SnapKit" */;
+			productName = SnapKit;
+		};
+		4A47164C29F8EB2600CBE9C8 /* KakaoSDKUser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4A47164B29F8EB2600CBE9C8 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKUser;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
+++ b/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
@@ -7,12 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4A0E8D5429F8346600E0FC23 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 4A0E8D5329F8346600E0FC23 /* FirebaseAnalyticsWithoutAdIdSupport */; };
+		4A0E8D5629F8346600E0FC23 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 4A0E8D5529F8346600E0FC23 /* FirebaseMessaging */; };
 		4A8FFA5029C9E1FD00FB76C0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8FFA4F29C9E1FD00FB76C0 /* AppDelegate.swift */; };
 		4A8FFA5229C9E1FD00FB76C0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8FFA5129C9E1FD00FB76C0 /* SceneDelegate.swift */; };
 		4A8FFA5429C9E1FD00FB76C0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8FFA5329C9E1FD00FB76C0 /* ViewController.swift */; };
 		4A8FFA5729C9E1FD00FB76C0 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4A8FFA5529C9E1FD00FB76C0 /* Main.storyboard */; };
 		4A8FFA5929C9E1FE00FB76C0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4A8FFA5829C9E1FE00FB76C0 /* Assets.xcassets */; };
 		4A8FFA5C29C9E1FE00FB76C0 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4A8FFA5A29C9E1FE00FB76C0 /* LaunchScreen.storyboard */; };
+		4AC9489829ED800800489C2B /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4AC9489729ED800800489C2B /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -25,6 +28,7 @@
 		4A8FFA5829C9E1FE00FB76C0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4A8FFA5B29C9E1FE00FB76C0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		4A8FFA5D29C9E1FE00FB76C0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4AC9489729ED800800489C2B /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -32,6 +36,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4A0E8D5629F8346600E0FC23 /* FirebaseMessaging in Frameworks */,
+				4A0E8D5429F8346600E0FC23 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -58,6 +64,7 @@
 			isa = PBXGroup;
 			children = (
 				4A4E21EE29D9B02500BF8747 /* Smeem-iOS.entitlements */,
+				4AC9489729ED800800489C2B /* GoogleService-Info.plist */,
 				4A8FFA4F29C9E1FD00FB76C0 /* AppDelegate.swift */,
 				4A8FFA5129C9E1FD00FB76C0 /* SceneDelegate.swift */,
 				4A8FFA5329C9E1FD00FB76C0 /* ViewController.swift */,
@@ -85,6 +92,10 @@
 			dependencies = (
 			);
 			name = "Smeem-iOS";
+			packageProductDependencies = (
+				4A0E8D5329F8346600E0FC23 /* FirebaseAnalyticsWithoutAdIdSupport */,
+				4A0E8D5529F8346600E0FC23 /* FirebaseMessaging */,
+			);
 			productName = "Smeem-iOS";
 			productReference = 4A8FFA4C29C9E1FD00FB76C0 /* Smeem-iOS.app */;
 			productType = "com.apple.product-type.application";
@@ -113,6 +124,9 @@
 				Base,
 			);
 			mainGroup = 4A8FFA4329C9E1FD00FB76C0;
+			packageReferences = (
+				4A0E8D5229F8346600E0FC23 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+			);
 			productRefGroup = 4A8FFA4D29C9E1FD00FB76C0 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -128,6 +142,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4A8FFA5C29C9E1FE00FB76C0 /* LaunchScreen.storyboard in Resources */,
+				4AC9489829ED800800489C2B /* GoogleService-Info.plist in Resources */,
 				4A8FFA5929C9E1FE00FB76C0 /* Assets.xcassets in Resources */,
 				4A8FFA5729C9E1FD00FB76C0 /* Main.storyboard in Resources */,
 			);
@@ -372,6 +387,30 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		4A0E8D5229F8346600E0FC23 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		4A0E8D5329F8346600E0FC23 /* FirebaseAnalyticsWithoutAdIdSupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4A0E8D5229F8346600E0FC23 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsWithoutAdIdSupport;
+		};
+		4A0E8D5529F8346600E0FC23 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4A0E8D5229F8346600E0FC23 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 4A8FFA4429C9E1FD00FB76C0 /* Project object */;
 }

--- a/Smeem-iOS/Smeem-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Smeem-iOS/Smeem-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,104 @@
+{
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "a5f16ba68913840ee5df91b8dc06f5cc063579de",
+        "version" : "1.2021110200.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "branch" : "master",
+        "revision" : "6504a2b98be383cc2d3c164284d186ac982d3a8c"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "274428b83e063cd518b998555be0ec18abcbe9de",
+        "version" : "10.8.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "cc7265b8e3906304e6e81f32c1662a94bbae2357",
+        "version" : "9.2.2"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "871d43135925cde39ef7421d8723ce47edfdcc39",
+        "version" : "7.11.1"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "df37f6af8a273bc687e3166843ed86007de57d78",
+        "version" : "1.44.0"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "96d7cc73a71ce950723aa3c50ce4fb275ae180b8",
+        "version" : "3.1.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
+        "version" : "1.22.2"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+        "version" : "2.30909.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "ec957ccddbcc710ccc64c9dcbd4c7006fcf8b73a",
+        "version" : "2.2.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "0af9125c4eae12a4973fb66574c53a54962a9e1e",
+        "version" : "1.21.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Smeem-iOS/Smeem-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Smeem-iOS/Smeem-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "78424be314842833c04bc3bef5b72e85fff99204",
+        "version" : "5.6.4"
+      }
+    },
+    {
       "identity" : "firebase-ios-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
@@ -64,6 +73,15 @@
       }
     },
     {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "d788f9a5a888f16253b9c3d9f3bd794835708c3f",
+        "version" : "2.15.0"
+      }
+    },
+    {
       "identity" : "leveldb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",
@@ -88,6 +106,15 @@
       "state" : {
         "revision" : "ec957ccddbcc710ccc64c9dcbd4c7006fcf8b73a",
         "version" : "2.2.0"
+      }
+    },
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit",
+      "state" : {
+        "revision" : "f222cbdf325885926566172f6f5f06af95473158",
+        "version" : "5.6.0"
       }
     },
     {

--- a/Smeem-iOS/Smeem-iOS/AppDelegate.swift
+++ b/Smeem-iOS/Smeem-iOS/AppDelegate.swift
@@ -11,13 +11,15 @@ import UIKit
 import Firebase
 import FirebaseCore
 import FirebaseMessaging
+import KakaoSDKCommon
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
-    var window: UIWindow?
-    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        let nativeAppKey = Bundle.main.object(forInfoDictionaryKey: "NATIVE_APP_KEY") as? String ?? ""
+        KakaoSDK.initSDK(appKey: nativeAppKey)
+        
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         appleIDProvider.getCredentialState(forUserID: "") { (credentialState, error) in
             switch credentialState {

--- a/Smeem-iOS/Smeem-iOS/AppDelegate.swift
+++ b/Smeem-iOS/Smeem-iOS/AppDelegate.swift
@@ -7,14 +7,57 @@
 
 import UIKit
 
+import FirebaseCore
+import FirebaseMessaging
+
 @main
-class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
-
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, MessagingDelegate {
+    
+    var window: UIWindow?
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        FirebaseApp.configure()
+        
+        // 메시지 대리자 설정
+        Messaging.messaging().delegate = self
+        
+        UNUserNotificationCenter.current().delegate = self
+
+        let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+        UNUserNotificationCenter
+          .current()
+          .requestAuthorization(
+            options: authOptions,completionHandler: { (_, _) in }
+          )
+        
+        // APNs 등록
+        application.registerForRemoteNotifications()
         return true
+    }
+    
+    // deviceToken을 할당하여 Firebase Messaging 서버에 토큰 등록
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        Messaging.messaging().apnsToken = deviceToken
+    }
+    
+    // 현재 토큰 가져오기
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        // 토큰 갱신 모니터링
+        let dataDict: [String: String] = ["token": fcmToken ?? ""]
+        NotificationCenter.default.post(
+            name: Notification.Name("FCMToken"),
+            object: nil,
+            userInfo: dataDict
+        )
+        
+        // 등록된 토큰 가져오기
+        Messaging.messaging().token { token, error in
+          if let error = error {
+            print("Error fetching FCM registration token: \(error)")
+          } else if let token = token {
+            print("FCM registration token: \(token)")
+          }
+        }
     }
 
     // MARK: UISceneSession Lifecycle

--- a/Smeem-iOS/Smeem-iOS/AppDelegate.swift
+++ b/Smeem-iOS/Smeem-iOS/AppDelegate.swift
@@ -5,23 +5,45 @@
 //  Created by 황찬미 on 2023/03/21.
 //
 
+import AuthenticationServices
 import UIKit
 
+import Firebase
 import FirebaseCore
 import FirebaseMessaging
 
 @main
-class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, MessagingDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate {
     
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        appleIDProvider.getCredentialState(forUserID: "") { (credentialState, error) in
+            switch credentialState {
+            case .authorized:
+                // The Apple ID credential is valid.
+                print("해당 ID는 연동되어있습니다.")
+            case .revoked:
+                // The Apple ID credential is either revoked or was not found, so show the sign-in UI.
+                print("해당 ID는 연동되어있지않습니다.")
+            case .notFound:
+                // The Apple ID credential is either was not found, so show the sign-in UI.
+                print("해당 ID를 찾을 수 없습니다.")
+            default:
+                break
+            }
+        }
+        //앱 실행 중 강제로 연결 취소 시
+        NotificationCenter.default.addObserver(forName: ASAuthorizationAppleIDProvider.credentialRevokedNotification, object: nil, queue: nil) { (Notification) in
+            print("Revoked Notification")
+            // 로그인 페이지로 이동
+        }
+    
         FirebaseApp.configure()
         
         // 메시지 대리자 설정
         Messaging.messaging().delegate = self
-        
-        UNUserNotificationCenter.current().delegate = self
 
         let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
         UNUserNotificationCenter
@@ -39,26 +61,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         Messaging.messaging().apnsToken = deviceToken
     }
-    
-    // 현재 토큰 가져오기
-    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-        // 토큰 갱신 모니터링
-        let dataDict: [String: String] = ["token": fcmToken ?? ""]
-        NotificationCenter.default.post(
-            name: Notification.Name("FCMToken"),
-            object: nil,
-            userInfo: dataDict
-        )
-        
-        // 등록된 토큰 가져오기
-        Messaging.messaging().token { token, error in
-          if let error = error {
-            print("Error fetching FCM registration token: \(error)")
-          } else if let token = token {
-            print("FCM registration token: \(token)")
-          }
-        }
-    }
 
     // MARK: UISceneSession Lifecycle
 
@@ -75,5 +77,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
 
+}
+
+// MARK: - MessagingDelegate
+
+extension AppDelegate: MessagingDelegate {
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        // 등록된 토큰 가져오기
+        Messaging.messaging().token { token, error in
+          if let error = error {
+            print("Error fetching FCM registration token: \(error)")
+          } else if let token = token {
+            print("FCM registration token: \(token)")
+          }
+        }
+    }
 }
 

--- a/Smeem-iOS/Smeem-iOS/AuthViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/AuthViewController.swift
@@ -9,6 +9,7 @@ import AuthenticationServices
 import UIKit
 
 import SnapKit
+import KakaoSDKUser
 
 final class AuthViewController: UIViewController {
     
@@ -18,11 +19,41 @@ final class AuthViewController: UIViewController {
         return appleLoginButton
     }()
     
+    private lazy var kakaoLoginButton: UIButton = {
+        let kakaoLoginButton = UIButton()
+        kakaoLoginButton.backgroundColor = .blue
+        kakaoLoginButton.addTarget(self, action: #selector(loginKakao), for: .touchUpInside)
+        return kakaoLoginButton
+    }()
+    
+    private lazy var outBUtton: UIButton = {
+        let outBUtton = UIButton()
+        outBUtton.backgroundColor = .blue
+        outBUtton.addTarget(self, action: #selector(unlinkClicked), for: .touchUpInside)
+        return outBUtton
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
         
         setupProviderLoginView()
+        
+        view.addSubview(kakaoLoginButton)
+        
+        kakaoLoginButton.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(100)
+            $0.centerX.equalToSuperview()
+            $0.width.height.equalTo(30)
+        }
+        
+        view.addSubview(outBUtton)
+        
+        outBUtton.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(200)
+            $0.centerX.equalToSuperview()
+            $0.width.height.equalTo(30)
+        }
     }
     
     // 로그인 버튼 추가
@@ -37,8 +68,8 @@ final class AuthViewController: UIViewController {
     }
 }
 
+// MARK: - Apple Login
 extension AuthViewController: ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
-    
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         self.view.window!
     }
@@ -81,5 +112,46 @@ extension AuthViewController: ASAuthorizationControllerDelegate, ASAuthorization
     // 사용자 인증 실패했을 때
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
       // Handle error.
+    }
+}
+
+// MARK: - Kakao Login
+
+extension AuthViewController {
+    @objc func loginKakao() {
+        print("loginKakao() called.")
+
+        // 카카오톡 설치 여부 확인
+        if (UserApi.isKakaoTalkLoginAvailable()) {
+            UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
+                    if let error = error {
+                        print(error)
+                    }
+                    else {
+                        print("loginWithKakaoAccount() success.")
+
+                        //do something
+                        print("🧡 \(oauthToken)")
+                    }
+                }
+        }
+        // 카카오톡 미설치
+        else {
+            print("카카오톡 미설치")
+        }
+    }
+    
+    @objc func unlinkClicked(_ sender: Any) {
+        // 연결 끊기 : 연결이 끊어지면 기존의 토큰은 더 이상 사용할 수 없으므로, 연결 끊기 API 요청 성공 시 로그아웃 처리가 함께 이뤄져 토큰이 삭제됩니다.
+        UserApi.shared.unlink {(error) in
+            if let error = error {
+                print(error)
+            }
+            else {
+                print("unlink() success.")
+
+                // 연결끊기 시 메인으로 보냄
+            }
+        }
     }
 }

--- a/Smeem-iOS/Smeem-iOS/AuthViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/AuthViewController.swift
@@ -1,0 +1,85 @@
+//
+//  AuthController.swift
+//  Smeem-iOS
+//
+//  Created by 황찬미 on 2023/04/26.
+//
+
+import AuthenticationServices
+import UIKit
+
+import SnapKit
+
+final class AuthViewController: UIViewController {
+    
+    private lazy var appleLoginButton: UIView = {
+        let appleLoginButton = UIView()
+        appleLoginButton.backgroundColor = .black
+        return appleLoginButton
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        
+        setupProviderLoginView()
+    }
+    
+    // 로그인 버튼 추가
+    func setupProviderLoginView() {
+      let authorizationButton = ASAuthorizationAppleIDButton()
+      authorizationButton.addTarget(self, action: #selector(handleAuthorizationAppleIDButtonPress), for: .touchUpInside)
+      view.addSubview(authorizationButton)
+        
+        authorizationButton.snp.makeConstraints {
+            $0.centerX.centerY.equalToSuperview()
+        }
+    }
+}
+
+extension AuthViewController: ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+    
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        self.view.window!
+    }
+    
+    // apple 승인 요청
+    @objc func handleAuthorizationAppleIDButtonPress() {
+      let appleIDProvider = ASAuthorizationAppleIDProvider()
+      let request = appleIDProvider.createRequest()
+      request.requestedScopes = [.fullName, .email]
+        
+      let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+      authorizationController.delegate = self
+      authorizationController.presentationContextProvider = self
+      authorizationController.performRequests()
+    }
+    
+    // 사용자 인증 후 처리
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        switch authorization.credential {
+              // Apple ID
+          case let appleIDCredential as ASAuthorizationAppleIDCredential:
+              
+              // 계정 정보 가져오기
+              let userIdentifier = appleIDCredential.user
+              let fullName = appleIDCredential.fullName
+              let email = appleIDCredential.email
+              let idToken = appleIDCredential.identityToken!
+              let tokeStr = String(data: idToken, encoding: .utf8)
+           
+              print("User ID : \(userIdentifier)")
+              print("User Email : \(email ?? "")")
+              print("User Name : \((fullName?.givenName ?? "") + (fullName?.familyName ?? ""))")
+              print("token : \(String(describing: tokeStr))")
+              
+          default:
+              break
+          }
+    }
+    
+    // 사용자 인증 실패했을 때
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+      // Handle error.
+    }
+}

--- a/Smeem-iOS/Smeem-iOS/GoogleService-Info.plist
+++ b/Smeem-iOS/Smeem-iOS/GoogleService-Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>511453650235-9jtht4929viiurb80d9uvm0lb7q6ejsi.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.511453650235-9jtht4929viiurb80d9uvm0lb7q6ejsi</string>
+	<key>API_KEY</key>
+	<string>AIzaSyBobOUS0iP9OT77kviGVPA8uhgTDSM_3O4</string>
+	<key>GCM_SENDER_ID</key>
+	<string>511453650235</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>Team.Smeem-iOS</string>
+	<key>PROJECT_ID</key>
+	<string>smeem-303d1</string>
+	<key>STORAGE_BUCKET</key>
+	<string>smeem-303d1.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:511453650235:ios:c5eb3acf65e2226903ab1e</string>
+</dict>
+</plist>

--- a/Smeem-iOS/Smeem-iOS/Info.plist
+++ b/Smeem-iOS/Smeem-iOS/Info.plist
@@ -2,6 +2,24 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaolink</string>
+		<string>kakaokompassauth</string>
+	</array>
+	<key>NATIVE_APP_KEY</key>
+	<string>$(NATIVE_APP_KEY)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao$(NATIVE_APP_KEY)</string>
+			</array>
+		</dict>
+	</array>
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<false/>
 	<key>FirebaseMessagingAutoInitEnabled</key>

--- a/Smeem-iOS/Smeem-iOS/Info.plist
+++ b/Smeem-iOS/Smeem-iOS/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
+	<key>FirebaseMessagingAutoInitEnabled</key>
+	<false/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -21,5 +25,9 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>

--- a/Smeem-iOS/Smeem-iOS/SceneDelegate.swift
+++ b/Smeem-iOS/Smeem-iOS/SceneDelegate.swift
@@ -7,17 +7,25 @@
 
 import UIKit
 
+import KakaoSDKAuth
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        
         guard let scene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: scene)
         self.window?.rootViewController = AuthViewController()
         self.window?.makeKeyAndVisible()
+    }
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        if let url = URLContexts.first?.url {
+            if AuthApi.isKakaoTalkLoginUrl(url) {
+                _ = AuthController.handleOpenUrl(url: url)
+            }
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Smeem-iOS/Smeem-iOS/SceneDelegate.swift
+++ b/Smeem-iOS/Smeem-iOS/SceneDelegate.swift
@@ -13,10 +13,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        
+        guard let scene = (scene as? UIWindowScene) else { return }
+        self.window = UIWindow(windowScene: scene)
+        self.window?.rootViewController = AuthViewController()
+        self.window?.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
- 푸시 알림 및 애플, 카카오 소셜로그인 간단한 세팅해 놨습니다.
- 이번에는 xcconfig 파일을 이용해서 nativa app key 값을 숨겨 놓았고, 개발자들이 로컬에 들고 있는 방식으로 진행해 보려고 해요. config 파일은 카톡으로 따로 보내드리겠습니다!
- API 통신 잘되는지 확인용으로 AuthViewController를 미리 만들었기 때문에, 준 오빠는 폴더링할 때 이점 참고해 주세요.
- 그리고 다들 gitignore에 추가했지만 자꾸 추적하는 파일들이 있을 거예요. 다들 풀 받고 작업하기 전에 해당 파일 추적하지 못하도록 캐시를 지워 주세요.