### PR TITLE
[Feat] #14 - 온보딩 UI 구현

### DIFF
--- a/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
+++ b/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		4AD923E72A0650B600FF5E27 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD923E62A0650B600FF5E27 /* SplashViewController.swift */; };
 		4AD923E92A0692C600FF5E27 /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD923E82A0692C600FF5E27 /* BottomSheetViewController.swift */; };
 		4AD923EB2A0692EA00FF5E27 /* BottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD923EA2A0692EA00FF5E27 /* BottomSheetView.swift */; };
+		4AF507752A10CD4D007C62B1 /* GoalOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF507742A10CD4D007C62B1 /* GoalOnboardingViewController.swift */; };
+		4AF507772A10CD96007C62B1 /* GoalCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF507762A10CD96007C62B1 /* GoalCollectionViewCell.swift */; };
 		6F62668C2A04EA3B000365CD /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F62668B2A04EA3B000365CD /* HomeViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -90,6 +92,8 @@
 		4AD923E62A0650B600FF5E27 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		4AD923E82A0692C600FF5E27 /* BottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewController.swift; sourceTree = "<group>"; };
 		4AD923EA2A0692EA00FF5E27 /* BottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetView.swift; sourceTree = "<group>"; };
+		4AF507742A10CD4D007C62B1 /* GoalOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalOnboardingViewController.swift; sourceTree = "<group>"; };
+		4AF507762A10CD96007C62B1 /* GoalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalCollectionViewCell.swift; sourceTree = "<group>"; };
 		6F62668B2A04EA3B000365CD /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -126,6 +130,7 @@
 			isa = PBXGroup;
 			children = (
 				4AD923E52A0650A000FF5E27 /* Splash */,
+				4AF5076F2A10CBA2007C62B1 /* Onboarding */,
 				4AE4B5172A06BF4A00D45F87 /* BottomSheet */,
 				4A3F2E952A0ABB9C00F6AC60 /* Alarm */,
 				6F62668A2A04E889000365CD /* Home */,
@@ -307,6 +312,15 @@
 			path = BottomSheet;
 			sourceTree = "<group>";
 		};
+		4AF5076F2A10CBA2007C62B1 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				4AF507742A10CD4D007C62B1 /* GoalOnboardingViewController.swift */,
+				4AF507762A10CD96007C62B1 /* GoalCollectionViewCell.swift */,
+			);
+			path = Onboarding;
+			sourceTree = "<group>";
+		};
 		6F62668A2A04E889000365CD /* Home */ = {
 			isa = PBXGroup;
 			children = (
@@ -410,6 +424,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				37A574C529FF6EA800312453 /* FontLiterals.swift in Sources */,
+				4AF507772A10CD96007C62B1 /* GoalCollectionViewCell.swift in Sources */,
 				4AD923E92A0692C600FF5E27 /* BottomSheetViewController.swift in Sources */,
 				4A8FFA5429C9E1FD00FB76C0 /* ViewController.swift in Sources */,
 				37A574CC29FF990E00312453 /* UIViewController+.swift in Sources */,
@@ -437,6 +452,7 @@
 				4A8FFA5229C9E1FD00FB76C0 /* SceneDelegate.swift in Sources */,
 				37A574E82A02424F00312453 /* RandomSubjectView.swift in Sources */,
 				4A0EA4642A014710006CCE52 /* SmeemButton.swift in Sources */,
+				4AF507752A10CD4D007C62B1 /* GoalOnboardingViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
+++ b/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
@@ -48,6 +48,9 @@
 		4AD923E72A0650B600FF5E27 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD923E62A0650B600FF5E27 /* SplashViewController.swift */; };
 		4AD923E92A0692C600FF5E27 /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD923E82A0692C600FF5E27 /* BottomSheetViewController.swift */; };
 		4AD923EB2A0692EA00FF5E27 /* BottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD923EA2A0692EA00FF5E27 /* BottomSheetView.swift */; };
+		4AEFD4C52A136EE100DAB2BD /* HowOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFD4C42A136EE100DAB2BD /* HowOnboardingViewController.swift */; };
+		4AEFD4C82A13908E00DAB2BD /* AlarmViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFD4C72A13908E00DAB2BD /* AlarmViewController.swift */; };
+		4AEFD4CA2A1392DF00DAB2BD /* HowLearningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFD4C92A1392DF00DAB2BD /* HowLearningView.swift */; };
 		4AF507752A10CD4D007C62B1 /* GoalOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF507742A10CD4D007C62B1 /* GoalOnboardingViewController.swift */; };
 		4AF507772A10CD96007C62B1 /* GoalCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF507762A10CD96007C62B1 /* GoalCollectionViewCell.swift */; };
 		6F62668C2A04EA3B000365CD /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F62668B2A04EA3B000365CD /* HomeViewController.swift */; };
@@ -92,6 +95,9 @@
 		4AD923E62A0650B600FF5E27 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		4AD923E82A0692C600FF5E27 /* BottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewController.swift; sourceTree = "<group>"; };
 		4AD923EA2A0692EA00FF5E27 /* BottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetView.swift; sourceTree = "<group>"; };
+		4AEFD4C42A136EE100DAB2BD /* HowOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HowOnboardingViewController.swift; sourceTree = "<group>"; };
+		4AEFD4C72A13908E00DAB2BD /* AlarmViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmViewController.swift; sourceTree = "<group>"; };
+		4AEFD4C92A1392DF00DAB2BD /* HowLearningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HowLearningView.swift; sourceTree = "<group>"; };
 		4AF507742A10CD4D007C62B1 /* GoalOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalOnboardingViewController.swift; sourceTree = "<group>"; };
 		4AF507762A10CD96007C62B1 /* GoalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalCollectionViewCell.swift; sourceTree = "<group>"; };
 		6F62668B2A04EA3B000365CD /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
@@ -312,11 +318,38 @@
 			path = BottomSheet;
 			sourceTree = "<group>";
 		};
-		4AF5076F2A10CBA2007C62B1 /* Onboarding */ = {
+		4AEFD4C22A136E5F00DAB2BD /* Goal */ = {
 			isa = PBXGroup;
 			children = (
 				4AF507742A10CD4D007C62B1 /* GoalOnboardingViewController.swift */,
 				4AF507762A10CD96007C62B1 /* GoalCollectionViewCell.swift */,
+			);
+			path = Goal;
+			sourceTree = "<group>";
+		};
+		4AEFD4C32A136E6F00DAB2BD /* How */ = {
+			isa = PBXGroup;
+			children = (
+				4AEFD4C42A136EE100DAB2BD /* HowOnboardingViewController.swift */,
+				4AEFD4C92A1392DF00DAB2BD /* HowLearningView.swift */,
+			);
+			path = How;
+			sourceTree = "<group>";
+		};
+		4AEFD4C62A13907D00DAB2BD /* Alarm */ = {
+			isa = PBXGroup;
+			children = (
+				4AEFD4C72A13908E00DAB2BD /* AlarmViewController.swift */,
+			);
+			path = Alarm;
+			sourceTree = "<group>";
+		};
+		4AF5076F2A10CBA2007C62B1 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				4AEFD4C62A13907D00DAB2BD /* Alarm */,
+				4AEFD4C22A136E5F00DAB2BD /* Goal */,
+				4AEFD4C32A136E6F00DAB2BD /* How */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -423,9 +456,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4AEFD4C82A13908E00DAB2BD /* AlarmViewController.swift in Sources */,
 				37A574C529FF6EA800312453 /* FontLiterals.swift in Sources */,
+				4AEFD4C52A136EE100DAB2BD /* HowOnboardingViewController.swift in Sources */,
 				4AF507772A10CD96007C62B1 /* GoalCollectionViewCell.swift in Sources */,
 				4AD923E92A0692C600FF5E27 /* BottomSheetViewController.swift in Sources */,
+				4AEFD4CA2A1392DF00DAB2BD /* HowLearningView.swift in Sources */,
 				4A8FFA5429C9E1FD00FB76C0 /* ViewController.swift in Sources */,
 				37A574CC29FF990E00312453 /* UIViewController+.swift in Sources */,
 				37A574C329FF6E9C00312453 /* ImageLiterals.swift in Sources */,

--- a/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
+++ b/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
@@ -49,7 +49,7 @@
 		4AD923E92A0692C600FF5E27 /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD923E82A0692C600FF5E27 /* BottomSheetViewController.swift */; };
 		4AD923EB2A0692EA00FF5E27 /* BottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD923EA2A0692EA00FF5E27 /* BottomSheetView.swift */; };
 		4AEFD4C52A136EE100DAB2BD /* HowOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFD4C42A136EE100DAB2BD /* HowOnboardingViewController.swift */; };
-		4AEFD4C82A13908E00DAB2BD /* AlarmViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFD4C72A13908E00DAB2BD /* AlarmViewController.swift */; };
+		4AEFD4C82A13908E00DAB2BD /* AlarmSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFD4C72A13908E00DAB2BD /* AlarmSettingViewController.swift */; };
 		4AEFD4CA2A1392DF00DAB2BD /* HowLearningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFD4C92A1392DF00DAB2BD /* HowLearningView.swift */; };
 		4AF507752A10CD4D007C62B1 /* GoalOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF507742A10CD4D007C62B1 /* GoalOnboardingViewController.swift */; };
 		4AF507772A10CD96007C62B1 /* GoalCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF507762A10CD96007C62B1 /* GoalCollectionViewCell.swift */; };
@@ -96,7 +96,7 @@
 		4AD923E82A0692C600FF5E27 /* BottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewController.swift; sourceTree = "<group>"; };
 		4AD923EA2A0692EA00FF5E27 /* BottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetView.swift; sourceTree = "<group>"; };
 		4AEFD4C42A136EE100DAB2BD /* HowOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HowOnboardingViewController.swift; sourceTree = "<group>"; };
-		4AEFD4C72A13908E00DAB2BD /* AlarmViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmViewController.swift; sourceTree = "<group>"; };
+		4AEFD4C72A13908E00DAB2BD /* AlarmSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmSettingViewController.swift; sourceTree = "<group>"; };
 		4AEFD4C92A1392DF00DAB2BD /* HowLearningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HowLearningView.swift; sourceTree = "<group>"; };
 		4AF507742A10CD4D007C62B1 /* GoalOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalOnboardingViewController.swift; sourceTree = "<group>"; };
 		4AF507762A10CD96007C62B1 /* GoalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -339,7 +339,7 @@
 		4AEFD4C62A13907D00DAB2BD /* Alarm */ = {
 			isa = PBXGroup;
 			children = (
-				4AEFD4C72A13908E00DAB2BD /* AlarmViewController.swift */,
+				4AEFD4C72A13908E00DAB2BD /* AlarmSettingViewController.swift */,
 			);
 			path = Alarm;
 			sourceTree = "<group>";
@@ -456,7 +456,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4AEFD4C82A13908E00DAB2BD /* AlarmViewController.swift in Sources */,
+				4AEFD4C82A13908E00DAB2BD /* AlarmSettingViewController.swift in Sources */,
 				37A574C529FF6EA800312453 /* FontLiterals.swift in Sources */,
 				4AEFD4C52A136EE100DAB2BD /* HowOnboardingViewController.swift in Sources */,
 				4AF507772A10CD96007C62B1 /* GoalCollectionViewCell.swift in Sources */,

--- a/Smeem-iOS/Smeem-iOS/Global/Extensions/UIViewController+.swift
+++ b/Smeem-iOS/Smeem-iOS/Global/Extensions/UIViewController+.swift
@@ -57,4 +57,9 @@ extension UIViewController {
     func convertByHeightRatio(_ convert: CGFloat) -> CGFloat {
         return (convert / 812) * getDeviceHeight()
     }
+    
+    /// 상단 네비바 hidden
+    func hiddenNavigationBar() {
+        self.navigationController?.isNavigationBarHidden = true
+    }
 }

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Alarm/AlarmSettingViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Alarm/AlarmSettingViewController.swift
@@ -1,0 +1,142 @@
+//
+//  AlarmSettingViewController.swift
+//  Smeem-iOS
+//
+//  Created by 황찬미 on 2023/05/16.
+//
+
+import UIKit
+
+final class AlarmSettingViewController: UIViewController {
+    
+    // MARK: - Property
+    
+    // MARK: - UI Property
+    
+    private let nowStepOneLabel: UILabel = {
+        let label = UILabel()
+        label.text = "3"
+        label.font = .s1
+        label.setTextWithLineHeight(lineHeight: 21)
+        label.textColor = .point
+        return label
+    }()
+    
+    private let divisionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "/"
+        label.font = .c3
+        label.textColor = .black
+        return label
+    }()
+    
+    private let totalStepLabel: UILabel = {
+        let label = UILabel()
+        label.text = "3"
+        label.font = .c3
+        label.textColor = .black
+        return label
+    }()
+    
+    private let titleTimeSettingLabel: UILabel = {
+        let label = UILabel()
+        label.text = "학습 시간 설정"
+        label.font = .h2
+        label.textColor = .black
+        return label
+    }()
+    
+    private let deatilTimeSettingLabel: UILabel = {
+        let label = UILabel()
+        label.text = "잊지 않도록 알림을 드릴게요."
+        label.font = .b4
+        label.textColor = .black
+        return label
+    }()
+    
+    private let timeSettingLabelStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.alignment = .leading
+        stackView.axis = .vertical
+        stackView.distribution = .fillProportionally
+        stackView.spacing = 6
+        return stackView
+    }()
+    
+    private let laterButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("나중에 설정하기", for: .normal)
+        button.setTitleColor(.gray600, for: .normal)
+        button.titleLabel?.font = .b4
+        return button
+    }()
+    
+    private let completeButton: SmeemButton = {
+        let button = SmeemButton()
+        button.setTitle("완료", for: .normal)
+        return button
+    }()
+    
+    private lazy var alarmCollectionView = AlarmCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setBackgroundColor()
+        setLayout()
+    }
+    
+    // MARK: - @objc
+    
+    // MARK: - Custom Method
+    
+    private func setBackgroundColor() {
+        view.backgroundColor = .smeemWhite
+    }
+    
+    private func setLayout() {
+        view.addSubviews(nowStepOneLabel, divisionLabel, totalStepLabel,                              timeSettingLabelStackView, alarmCollectionView, laterButton, completeButton)
+        timeSettingLabelStackView.addArrangedSubviews(titleTimeSettingLabel, deatilTimeSettingLabel)
+        
+        nowStepOneLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(26)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(36)
+        }
+        
+        divisionLabel.snp.makeConstraints {
+            $0.leading.equalTo(nowStepOneLabel.snp.trailing).offset(2)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(40)
+        }
+        
+        totalStepLabel.snp.makeConstraints {
+            $0.leading.equalTo(divisionLabel.snp.trailing).offset(1)
+            $0.top.equalTo(divisionLabel.snp.top)
+        }
+        
+        timeSettingLabelStackView.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(26)
+            $0.top.equalTo(totalStepLabel.snp.bottom).offset(19)
+        }
+        
+        alarmCollectionView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(26.5)
+            $0.top.equalTo(timeSettingLabelStackView.snp.bottom).offset(28)
+            $0.height.equalTo(convertByHeightRatio(133))
+        }
+        
+        completeButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(18)
+            $0.bottom.equalToSuperview().inset(50)
+            $0.height.equalTo(convertByHeightRatio(60))
+        }
+        
+        laterButton.snp.makeConstraints {
+            $0.bottom.equalTo(completeButton.snp.top).offset(-19)
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(19)
+        }
+    }
+
+}

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Goal/GoalOnboardingViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Goal/GoalOnboardingViewController.swift
@@ -77,6 +77,7 @@ final class GoalOnboardingViewController: UIViewController {
     private lazy var nextButton: SmeemButton = {
         let button = SmeemButton()
         button.setTitle("다음", for: .normal)
+        button.addTarget(self, action: #selector(nextButtonDidTap), for: .touchUpInside)
         return button
     }()
     
@@ -89,9 +90,15 @@ final class GoalOnboardingViewController: UIViewController {
         setLayout()
         setDelgate()
         setCellReigster()
+        hiddenNavigationBar()
     }
     
     // MARK: - @objc
+    
+    @objc func nextButtonDidTap() {
+        let howOnboardingVC = HowOnboardingViewController()
+        self.navigationController?.pushViewController(howOnboardingVC, animated: true)
+    }
     
     // MARK: - Custom Method
     

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/GoalCollectionViewCell.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/GoalCollectionViewCell.swift
@@ -1,0 +1,71 @@
+//
+//  GoalCollectionViewCell.swift
+//  Smeem-iOS
+//
+//  Created by 황찬미 on 2023/05/14.
+//
+
+import UIKit
+
+import SnapKit
+
+final class GoalCollectionViewCell: UICollectionViewCell {
+    
+    static let identifier = "OnboardingGoalCollectionViewCell"
+    
+    // MARK: - Property
+    
+    // MARK: - UI Property
+    
+    private let checkButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .point
+        return button
+    }()
+    
+    private let goalLabel: UILabel = {
+        let label = UILabel()
+        label.font = .b3
+        label.textColor = .gray600
+        return label
+    }()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+//        backgroundColor = .point
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - @objc
+    
+    // MARK: - Custom Method
+    
+    private func setLayout() {
+        addSubviews(checkButton, goalLabel)
+        
+        checkButton.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+            $0.width.height.equalTo(20)
+        }
+        
+        goalLabel.snp.makeConstraints {
+            $0.leading.equalTo(checkButton.snp.trailing).offset(12)
+            $0.centerY.equalToSuperview()
+        }
+    }
+    
+    func setData(_ text: String) {
+        goalLabel.text = text
+    }
+
+}
+
+

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/GoalCollectionViewCell.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/GoalCollectionViewCell.swift
@@ -11,6 +11,12 @@ import SnapKit
 
 final class GoalCollectionViewCell: UICollectionViewCell {
     
+    override var isSelected: Bool {
+        didSet {
+            setCellSelected(isSelected)
+        }
+    }
+    
     static let identifier = "OnboardingGoalCollectionViewCell"
     
     // MARK: - Property
@@ -19,7 +25,6 @@ final class GoalCollectionViewCell: UICollectionViewCell {
     
     private let checkButton: UIButton = {
         let button = UIButton()
-        button.backgroundColor = .point
         return button
     }()
     
@@ -35,8 +40,9 @@ final class GoalCollectionViewCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-//        backgroundColor = .point
+        setUI()
         setLayout()
+        setCellSelected(isSelected)
     }
     
     required init?(coder: NSCoder) {
@@ -46,6 +52,11 @@ final class GoalCollectionViewCell: UICollectionViewCell {
     // MARK: - @objc
     
     // MARK: - Custom Method
+    
+    private func setUI() {
+        makeRoundCorner(cornerRadius: 6)
+        layer.borderWidth = 1.5
+    }
     
     private func setLayout() {
         addSubviews(checkButton, goalLabel)
@@ -59,6 +70,16 @@ final class GoalCollectionViewCell: UICollectionViewCell {
         goalLabel.snp.makeConstraints {
             $0.leading.equalTo(checkButton.snp.trailing).offset(12)
             $0.centerY.equalToSuperview()
+        }
+    }
+    
+    func setCellSelected(_ selected: Bool) {
+        if isSelected {
+            layer.borderColor = UIColor.point.cgColor
+            checkButton.backgroundColor = .point
+        } else {
+            layer.borderColor = UIColor.gray100.cgColor
+            checkButton.backgroundColor = .blue
         }
     }
     

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/GoalOnboardingViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/GoalOnboardingViewController.swift
@@ -1,0 +1,179 @@
+//
+//  GoalOnboardingViewController.swift
+//  Smeem-iOS
+//
+//  Created by 황찬미 on 2023/05/14.
+//
+
+import UIKit
+
+final class GoalOnboardingViewController: UIViewController {
+    
+    // MARK: - Property
+    
+    let goalLabelList = ["자기계발", "취미로 즐기기", "현지 언어에 적응하기", "외국어 시험 고득점하기",
+                         "외국어 원서 독해", "아직 모르겠어요"]
+    
+    // MARK: - UI Property
+    
+    private let nowStepOneLabel: UILabel = {
+        let label = UILabel()
+        label.text = "1"
+        label.font = .s1
+        label.setTextWithLineHeight(lineHeight: 21)
+        label.textColor = .point
+        return label
+    }()
+    
+    private let divisionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "/"
+        label.font = .c3
+        label.textColor = .black
+        return label
+    }()
+    
+    private let totalStepLabel: UILabel = {
+        let label = UILabel()
+        label.text = "3"
+        label.font = .c3
+        label.textColor = .black
+        return label
+    }()
+    
+    private let titleLearningLabel: UILabel = {
+        let label = UILabel()
+        label.text = "학습 목표 설정"
+        label.font = .h2
+        label.textColor = .black
+        return label
+    }()
+    
+    private let detailLearningLabel: UILabel = {
+        let label = UILabel()
+        label.text = "학습 목표는 마이페이지에서 수정할 수 있어요"
+        label.font = .b4
+        label.textColor = .black
+        return label
+    }()
+    
+    private let learningLabelStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.alignment = .leading
+        stackView.axis = .vertical
+        stackView.distribution = .fillProportionally
+        stackView.spacing = 6
+        return stackView
+    }()
+    
+    private lazy var learningListCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = .clear
+        collectionView.showsVerticalScrollIndicator = false
+        return collectionView
+    }()
+    
+    private lazy var nextButton: SmeemButton = {
+        let button = SmeemButton()
+        button.setTitle("다음", for: .normal)
+        return button
+    }()
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setBackgroundColor()
+        setLayout()
+        setDelgate()
+        setCellReigster()
+    }
+    
+    // MARK: - @objc
+    
+    // MARK: - Custom Method
+    
+    private func setBackgroundColor() {
+        view.backgroundColor = .white
+    }
+    
+    private func setLayout() {
+        view.addSubviews(nowStepOneLabel, divisionLabel, totalStepLabel,
+                         learningLabelStackView, learningListCollectionView,
+                         nextButton)
+        learningLabelStackView.addArrangedSubviews(titleLearningLabel, detailLearningLabel)
+        
+        nowStepOneLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(26)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(36)
+        }
+        
+        divisionLabel.snp.makeConstraints {
+            $0.leading.equalTo(nowStepOneLabel.snp.trailing).offset(2)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(40)
+        }
+        
+        totalStepLabel.snp.makeConstraints {
+            $0.leading.equalTo(divisionLabel.snp.trailing).offset(1)
+            $0.top.equalTo(divisionLabel.snp.top)
+        }
+        
+        learningLabelStackView.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(26)
+            $0.top.equalTo(totalStepLabel.snp.bottom).offset(19)
+        }
+        
+        learningListCollectionView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(18)
+            $0.top.equalTo(learningLabelStackView.snp.bottom).offset(28)
+        }
+        
+        nextButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(18)
+            $0.top.equalTo(learningListCollectionView.snp.bottom).offset(80)
+            $0.bottom.equalToSuperview().inset(50)
+            $0.height.equalTo(convertByHeightRatio(60))
+        }
+    }
+    
+    private func setDelgate() {
+        learningListCollectionView.delegate = self
+        learningListCollectionView.dataSource = self
+    }
+    
+    private func setCellReigster() {
+        learningListCollectionView.register(GoalCollectionViewCell.self, forCellWithReuseIdentifier: GoalCollectionViewCell.identifier)
+    }
+}
+
+extension GoalOnboardingViewController: UICollectionViewDelegate {
+    
+}
+
+extension GoalOnboardingViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return goalLabelList.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: GoalCollectionViewCell.identifier, for: indexPath) as? GoalCollectionViewCell else { return UICollectionViewCell() }
+        cell.setData(goalLabelList[indexPath.item])
+        return cell
+    }
+}
+
+extension GoalOnboardingViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let width = collectionView.frame.width
+        let height = convertByHeightRatio(60)
+        return CGSize(width: width, height: height)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        let cellLineSpacing: CGFloat = 12
+        return cellLineSpacing
+    }
+}
+

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/How/HowLearningView.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/How/HowLearningView.swift
@@ -5,6 +5,28 @@
 //  Created by 황찬미 on 2023/05/16.
 //
 
+/**
+ 1. 사용할 VC에서 호출
+private let howLearningView: HowLearningView = {
+ let view = HowLearningView()
+ return view
+ }()
+ 
+ 2. 자신이 사용할 UI에 맞는 ButtonType 설정 후 사용 (ButtonType은 logo, edit 두 개)
+ private let howLearningView: HowLearningView = {
+  let view = HowLearningView()
+  view.buttonType = .edit
+  return view
+  }()
+ 
+ 3. view 자체의 넓이와 높이값 줄 필요 없이  VC에서는 레이아웃만 잡아 주면 됨
+ ex) 예시임
+ howLearningView.snp.makeConstraints {
+     $0.top.equalTo(learningLabelStackView.snp.bottom).offset(28)
+     $0.centerX.equalToSuperview()
+ }
+ */
+
 import UIKit
 
 final class HowLearningView: UIView {

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/How/HowLearningView.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/How/HowLearningView.swift
@@ -1,0 +1,188 @@
+//
+//  HowLearningView.swift
+//  Smeem-iOS
+//
+//  Created by 황찬미 on 2023/05/16.
+//
+
+import UIKit
+
+final class HowLearningView: UIView {
+    
+    private let pointBackgroudView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .point
+        return view
+    }()
+    
+    private let smeemLogo: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .blue
+        return imageView
+    }()
+    
+    private let myGoalLabel: UILabel = {
+        let label = UILabel()
+        label.text = "나의 목표는"
+        label.font = .b3
+        label.textColor = .smeemWhite
+        return label
+    }()
+    
+    private let SelectedMyGoalLabel: UILabel = {
+        let label = UILabel()
+        label.text = "외국어 업무 문서 읽고 작성하기"
+        label.font = .h3
+        label.textColor = .smeemWhite
+        return label
+    }()
+    
+    private let grayLayerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .blue
+        return view
+    }()
+    
+    private let learningHowLabel: UILabel = {
+        let label = UILabel()
+        label.text = "학습 방법"
+        label.font = .s2
+        label.textColor = .smeemBlack
+        return label
+    }()
+    
+    private let firstSelectedLearningHowLabel: UILabel = {
+        let label = UILabel()
+        label.text = "주 3회 이상 일기 작성히기"
+        label.font = .b4
+        label.textColor = .gray600
+        return label
+    }()
+    
+    private let secondSelectedLearningHowLabel: UILabel = {
+        let label = UILabel()
+        label.text = "편지글 형태의 일기 작성하기"
+        label.font = .b4
+        label.textColor = .gray600
+        return label
+    }()
+    
+    private let deatilGoalLabel: UILabel = {
+        let label = UILabel()
+        label.text = "세부 목표"
+        label.font = .s2
+        label.textColor = .smeemBlack
+        return label
+    }()
+    
+    private let firstDetailLabel: UILabel = {
+        let label = UILabel()
+        label.text = "사전 보지 않고 일기 작성하기"
+        label.font = .b4
+        label.textColor = .gray600
+        return label
+    }()
+    
+    private let secondDetailLabel: UILabel = {
+        let label = UILabel()
+        label.text = "TOEIC 단어책 뭐뭐하기"
+        label.font = .b4
+        label.textColor = .gray600
+        return label
+    }()
+    
+    // MARK: - Property
+    
+    // MARK: - UI Property
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - @objc
+    
+    private func setUI() {
+        makeRoundCorner(cornerRadius: 10)
+        layer.borderWidth = 1.5
+        layer.borderColor = UIColor.gray100.cgColor
+    }
+    
+    private func setLayout() {
+        let howLearningViewWidth = 327
+        let howLearningViewHeight = 370
+        let pointBackgroundViewHeight = 129
+        
+        addSubviews(pointBackgroudView, learningHowLabel, firstSelectedLearningHowLabel,         secondSelectedLearningHowLabel, deatilGoalLabel, firstDetailLabel,           secondDetailLabel)
+        pointBackgroudView.addSubviews(smeemLogo, myGoalLabel, SelectedMyGoalLabel)
+        
+        self.snp.makeConstraints {
+            $0.width.equalTo(howLearningViewWidth)
+            $0.height.equalTo(howLearningViewHeight)
+        }
+        
+        pointBackgroudView.snp.makeConstraints {
+            $0.leading.trailing.top.equalToSuperview()
+            $0.width.equalTo(howLearningViewWidth)
+            $0.height.equalTo(pointBackgroundViewHeight)
+        }
+        
+        smeemLogo.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalToSuperview().inset(22)
+            $0.width.equalTo(33)
+            $0.height.equalTo(20)
+        }
+        
+        myGoalLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalTo(smeemLogo.snp.bottom).offset(23)
+        }
+        
+        SelectedMyGoalLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalTo(myGoalLabel.snp.bottom).offset(2)
+        }
+        
+        learningHowLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalTo(pointBackgroudView.snp.bottom).offset(24)
+        }
+        
+        firstSelectedLearningHowLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalTo(learningHowLabel.snp.bottom).offset(12)
+        }
+        
+        secondSelectedLearningHowLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalTo(firstSelectedLearningHowLabel.snp.bottom).offset(6)
+        }
+        
+        deatilGoalLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalTo(secondSelectedLearningHowLabel.snp.bottom).offset(39)
+        }
+        
+        firstDetailLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalTo(deatilGoalLabel.snp.bottom).offset(12)
+        }
+        
+        secondDetailLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalTo(firstDetailLabel.snp.bottom).offset(6)
+        }
+    }
+    
+    // MARK: - Custom Method
+
+}

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/How/HowLearningView.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/How/HowLearningView.swift
@@ -9,6 +9,19 @@ import UIKit
 
 final class HowLearningView: UIView {
     
+    // MARK: - ButtonType
+    
+    enum ButtonType {
+        case logo
+        case edit
+    }
+    
+    var buttontype: ButtonType = .logo {
+        didSet {
+            showButtonType()
+        }
+    }
+    
     private let pointBackgroudView: UIView = {
         let view = UIView()
         view.backgroundColor = .point
@@ -19,6 +32,12 @@ final class HowLearningView: UIView {
         let imageView = UIImageView()
         imageView.backgroundColor = .blue
         return imageView
+    }()
+    
+    private let editButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .black
+        return button
     }()
     
     private let myGoalLabel: UILabel = {
@@ -110,6 +129,8 @@ final class HowLearningView: UIView {
     
     // MARK: - @objc
     
+    // MARK: - Layout
+    
     private func setUI() {
         makeRoundCorner(cornerRadius: 10)
         layer.borderWidth = 1.5
@@ -122,7 +143,7 @@ final class HowLearningView: UIView {
         let pointBackgroundViewHeight = 129
         
         addSubviews(pointBackgroudView, learningHowLabel, firstSelectedLearningHowLabel,         secondSelectedLearningHowLabel, deatilGoalLabel, firstDetailLabel,           secondDetailLabel)
-        pointBackgroudView.addSubviews(smeemLogo, myGoalLabel, SelectedMyGoalLabel)
+        pointBackgroudView.addSubviews(smeemLogo, editButton, myGoalLabel, SelectedMyGoalLabel)
         
         self.snp.makeConstraints {
             $0.width.equalTo(howLearningViewWidth)
@@ -140,6 +161,11 @@ final class HowLearningView: UIView {
             $0.top.equalToSuperview().inset(22)
             $0.width.equalTo(33)
             $0.height.equalTo(20)
+        }
+        
+        editButton.snp.makeConstraints {
+            $0.trailing.top.equalToSuperview().inset(8)
+            $0.width.height.equalTo(25)
         }
         
         myGoalLabel.snp.makeConstraints {
@@ -184,5 +210,14 @@ final class HowLearningView: UIView {
     }
     
     // MARK: - Custom Method
+    
+    private func showButtonType() {
+        switch buttontype {
+        case .logo:
+            editButton.isHidden = true
+        case .edit:
+            smeemLogo.isHidden = true
+        }
+    }
 
 }

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/How/HowOnboardingViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/How/HowOnboardingViewController.swift
@@ -1,0 +1,130 @@
+//
+//  HowOnboardingViewController.swift
+//  Smeem-iOS
+//
+//  Created by 황찬미 on 2023/05/16.
+//
+
+import UIKit
+
+final class HowOnboardingViewController: UIViewController {
+    
+    // MARK: - Property
+    
+    // MARK: - UI Property
+    
+    private let nowStepOneLabel: UILabel = {
+        let label = UILabel()
+        label.text = "2"
+        label.font = .s1
+        label.setTextWithLineHeight(lineHeight: 21)
+        label.textColor = .point
+        return label
+    }()
+    
+    private let divisionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "/"
+        label.font = .c3
+        label.textColor = .black
+        return label
+    }()
+    
+    private let totalStepLabel: UILabel = {
+        let label = UILabel()
+        label.text = "3"
+        label.font = .c3
+        label.textColor = .black
+        return label
+    }()
+    
+    private let titleLearningLabel: UILabel = {
+        let label = UILabel()
+        label.text = "학습 권장 방법"
+        label.font = .h2
+        label.textColor = .black
+        return label
+    }()
+    
+    private let detailLearningLabel: UILabel = {
+        let label = UILabel()
+        label.text = "스밈과 이만큼 함께라면 목표를 이룰 수 있어요."
+        label.font = .b4
+        label.textColor = .black
+        return label
+    }()
+    
+    private let learningLabelStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.alignment = .leading
+        stackView.axis = .vertical
+        stackView.distribution = .fillProportionally
+        stackView.spacing = 6
+        return stackView
+    }()
+    
+    private let howLearningView: HowLearningView = {
+        let view = HowLearningView()
+        view.buttontype = .logo
+        return view
+    }()
+    
+    private let nextButton: SmeemButton = {
+        let button = SmeemButton()
+        button.setTitle("다음", for: .normal)
+        return button
+    }()
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setBackgroundColor()
+        setLayout()
+    }
+    
+    // MARK: - @objc
+    
+    // MARK: - Custom Method
+    
+    private func setBackgroundColor() {
+        view.backgroundColor = .white
+    }
+    
+    private func setLayout() {
+        view.addSubviews(nowStepOneLabel, divisionLabel, totalStepLabel,                              learningLabelStackView, howLearningView, nextButton)
+        learningLabelStackView.addArrangedSubviews(titleLearningLabel, detailLearningLabel)
+        
+        nowStepOneLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(26)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(36)
+        }
+        
+        divisionLabel.snp.makeConstraints {
+            $0.leading.equalTo(nowStepOneLabel.snp.trailing).offset(2)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(40)
+        }
+        
+        totalStepLabel.snp.makeConstraints {
+            $0.leading.equalTo(divisionLabel.snp.trailing).offset(1)
+            $0.top.equalTo(divisionLabel.snp.top)
+        }
+        
+        learningLabelStackView.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(26)
+            $0.top.equalTo(totalStepLabel.snp.bottom).offset(19)
+        }
+        
+        howLearningView.snp.makeConstraints {
+            $0.top.equalTo(learningLabelStackView.snp.bottom).offset(28)
+            $0.centerX.equalToSuperview()
+        }
+        
+        nextButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(18)
+            $0.bottom.equalToSuperview().inset(50)
+            $0.height.equalTo(convertByHeightRatio(60))
+        }
+    }
+}

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/How/HowOnboardingViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/How/HowOnboardingViewController.swift
@@ -69,9 +69,10 @@ final class HowOnboardingViewController: UIViewController {
         return view
     }()
     
-    private let nextButton: SmeemButton = {
+    private lazy var nextButton: SmeemButton = {
         let button = SmeemButton()
         button.setTitle("다음", for: .normal)
+        button.addTarget(self, action: #selector(nextButtonDidTap), for: .touchUpInside)
         return button
     }()
     
@@ -85,6 +86,11 @@ final class HowOnboardingViewController: UIViewController {
     }
     
     // MARK: - @objc
+    
+    @objc func nextButtonDidTap() {
+        let alarmVC = AlarmSettingViewController()
+        self.navigationController?.pushViewController(alarmVC, animated: true)
+    }
     
     // MARK: - Custom Method
     

--- a/Smeem-iOS/Smeem-iOS/Supports/SceneDelegate.swift
+++ b/Smeem-iOS/Smeem-iOS/Supports/SceneDelegate.swift
@@ -16,7 +16,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let scene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: scene)
-        self.window?.rootViewController = SplashViewController()
+        let rootViewViewController = UINavigationController(rootViewController: GoalOnboardingViewController())
+        self.window?.rootViewController = rootViewViewController
         self.window?.makeKeyAndVisible()
     }
     


### PR DESCRIPTION
##  작업한 내용
- 온보딩 UI 구현했어요

##  PR Point
- 기기대응은 마지막에 한번에 몰아서 할게요.
- 온보딩 첫 번째 학습 목표 설정 cell 선택시 버튼 활성화 처리는 아직 구현 안 했습니다.
- 온보딩 두 번째 학습 권장 방법 View로 따로 구현해 뒀어요. 종화 오빠 마이페이지에 사용되니까 파일 상단에 적어둔 사용 방법 보시고 사용하시면 됩니다.
- 추가로 현재 rootView를 온보딩 첫 화면으로 했고, navigation controller를 임베디드하고 있어요. 온보딩 과정을 거치고, 회원 정보를 모두 입력한 다음 주민이 뷰인 MainView로 rootView 화면 전환해 주는 과정을 해 줄 텐데요. 그러면 주민이 뷰에 navigationbar가 생길 거예요. extension에 nivagationbar hidden 처리하는 메서드 구현해 놨으니, 사용해 주시면 돼요.
- 공통으로 만든 컴포넌트들 폴더링을 고민 중인데... 이따 코어타임 때 같이 의논해 봅시다

## 스크린샷

|뷰|설명|
|------|---|
|![Simulator Screen Recording - iPhone 13 mini - 2023-05-16 at 21 16 38](https://github.com/Team-Smeme/Smeem-iOS/assets/86944161/3b3f2c3c-1888-4e80-b277-268bd37678e6)
   |    |

## 관련 이슈

- Resolved: #14
