### PR TITLE
[Feat] #24 - 닉네임 설정 및 서비스 이용약관 UI 구현

### DIFF
--- a/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
+++ b/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		4A3F2EA02A0C18B600F6AC60 /* DatePickerFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F2E9F2A0C18B600F6AC60 /* DatePickerFooterView.swift */; };
 		4A47164D29F8EB2600CBE9C8 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 4A47164C29F8EB2600CBE9C8 /* KakaoSDKUser */; };
 		4A47164F29F907FE00CBE9C8 /* Shared.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A47164E29F907FE00CBE9C8 /* Shared.xcconfig */; };
+		4A8275D32A1513120083A4AB /* ServiceAcceptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8275D22A1513120083A4AB /* ServiceAcceptViewController.swift */; };
+		4A8275D52A1519550083A4AB /* ServiceAcceptCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8275D42A1519550083A4AB /* ServiceAcceptCollectionViewCell.swift */; };
 		4A8FFA5029C9E1FD00FB76C0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8FFA4F29C9E1FD00FB76C0 /* AppDelegate.swift */; };
 		4A8FFA5229C9E1FD00FB76C0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8FFA5129C9E1FD00FB76C0 /* SceneDelegate.swift */; };
 		4A8FFA5929C9E1FE00FB76C0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4A8FFA5829C9E1FE00FB76C0 /* Assets.xcassets */; };
@@ -85,6 +87,8 @@
 		4A3F2E9F2A0C18B600F6AC60 /* DatePickerFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerFooterView.swift; sourceTree = "<group>"; };
 		4A47164E29F907FE00CBE9C8 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
 		4A4E21EE29D9B02500BF8747 /* Smeem-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Smeem-iOS.entitlements"; sourceTree = "<group>"; };
+		4A8275D22A1513120083A4AB /* ServiceAcceptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceAcceptViewController.swift; sourceTree = "<group>"; };
+		4A8275D42A1519550083A4AB /* ServiceAcceptCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceAcceptCollectionViewCell.swift; sourceTree = "<group>"; };
 		4A8FFA4C29C9E1FD00FB76C0 /* Smeem-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Smeem-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A8FFA4F29C9E1FD00FB76C0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		4A8FFA5129C9E1FD00FB76C0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -269,6 +273,15 @@
 			path = Alarm;
 			sourceTree = "<group>";
 		};
+		4A8275D12A15129B0083A4AB /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				4A8275D22A1513120083A4AB /* ServiceAcceptViewController.swift */,
+				4A8275D42A1519550083A4AB /* ServiceAcceptCollectionViewCell.swift */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
 		4A8FFA4329C9E1FD00FB76C0 = {
 			isa = PBXGroup;
 			children = (
@@ -350,6 +363,7 @@
 				4AEFD4C32A136E6F00DAB2BD /* How */,
 				4AEFD4C62A13907D00DAB2BD /* Alarm */,
 				4A13B7572A13D35800F4FB1E /* Nickname */,
+				4A8275D12A15129B0083A4AB /* Service */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -476,6 +490,7 @@
 				37A574CE29FF9A2D00312453 /* UIScreen+.swift in Sources */,
 				4A0EA4602A014139006CCE52 /* Service.swift in Sources */,
 				4A0EA4592A014103006CCE52 /* URLConstant.swift in Sources */,
+				4A8275D32A1513120083A4AB /* ServiceAcceptViewController.swift in Sources */,
 				4AD923E72A0650B600FF5E27 /* SplashViewController.swift in Sources */,
 				4AD923EB2A0692EA00FF5E27 /* BottomSheetView.swift in Sources */,
 				4A0EA4552A014027006CCE52 /* GeneralResponse.swift in Sources */,
@@ -484,6 +499,7 @@
 				37A574CA29FF980F00312453 /* UIStackView+.swift in Sources */,
 				4A13B7592A13D37000F4FB1E /* UserNickNameViewController.swift in Sources */,
 				4A0EA45E2A014134006CCE52 /* API.swift in Sources */,
+				4A8275D52A1519550083A4AB /* ServiceAcceptCollectionViewCell.swift in Sources */,
 				37A574E62A02178D00312453 /* CustomToastView.swift in Sources */,
 				4A8FFA5229C9E1FD00FB76C0 /* SceneDelegate.swift in Sources */,
 				37A574E82A02424F00312453 /* RandomSubjectView.swift in Sources */,

--- a/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
+++ b/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		4A0EA4602A014139006CCE52 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0EA45F2A014139006CCE52 /* Service.swift */; };
 		4A0EA4622A01413D006CCE52 /* DataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0EA4612A01413D006CCE52 /* DataModel.swift */; };
 		4A0EA4642A014710006CCE52 /* SmeemButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0EA4632A014710006CCE52 /* SmeemButton.swift */; };
+		4A13B7592A13D37000F4FB1E /* UserNickNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A13B7582A13D37000F4FB1E /* UserNickNameViewController.swift */; };
 		4A3F2E972A0ABBAA00F6AC60 /* AlarmCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F2E962A0ABBAA00F6AC60 /* AlarmCollectionViewCell.swift */; };
 		4A3F2E9C2A0B4C7100F6AC60 /* AlarmCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F2E9B2A0B4C7100F6AC60 /* AlarmCollectionView.swift */; };
 		4A3F2EA02A0C18B600F6AC60 /* DatePickerFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F2E9F2A0C18B600F6AC60 /* DatePickerFooterView.swift */; };
@@ -78,6 +79,7 @@
 		4A0EA45F2A014139006CCE52 /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		4A0EA4612A01413D006CCE52 /* DataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataModel.swift; sourceTree = "<group>"; };
 		4A0EA4632A014710006CCE52 /* SmeemButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmeemButton.swift; sourceTree = "<group>"; };
+		4A13B7582A13D37000F4FB1E /* UserNickNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNickNameViewController.swift; sourceTree = "<group>"; };
 		4A3F2E962A0ABBAA00F6AC60 /* AlarmCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmCollectionViewCell.swift; sourceTree = "<group>"; };
 		4A3F2E9B2A0B4C7100F6AC60 /* AlarmCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmCollectionView.swift; sourceTree = "<group>"; };
 		4A3F2E9F2A0C18B600F6AC60 /* DatePickerFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerFooterView.swift; sourceTree = "<group>"; };
@@ -249,6 +251,14 @@
 			path = DataModel;
 			sourceTree = "<group>";
 		};
+		4A13B7572A13D35800F4FB1E /* Nickname */ = {
+			isa = PBXGroup;
+			children = (
+				4A13B7582A13D37000F4FB1E /* UserNickNameViewController.swift */,
+			);
+			path = Nickname;
+			sourceTree = "<group>";
+		};
 		4A3F2E952A0ABB9C00F6AC60 /* Alarm */ = {
 			isa = PBXGroup;
 			children = (
@@ -339,6 +349,7 @@
 				4AEFD4C22A136E5F00DAB2BD /* Goal */,
 				4AEFD4C32A136E6F00DAB2BD /* How */,
 				4AEFD4C62A13907D00DAB2BD /* Alarm */,
+				4A13B7572A13D35800F4FB1E /* Nickname */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -471,6 +482,7 @@
 				4A8FFA5029C9E1FD00FB76C0 /* AppDelegate.swift in Sources */,
 				37A574C129FF6E9100312453 /* ColorLiterals.swift in Sources */,
 				37A574CA29FF980F00312453 /* UIStackView+.swift in Sources */,
+				4A13B7592A13D37000F4FB1E /* UserNickNameViewController.swift in Sources */,
 				4A0EA45E2A014134006CCE52 /* API.swift in Sources */,
 				37A574E62A02178D00312453 /* CustomToastView.swift in Sources */,
 				4A8FFA5229C9E1FD00FB76C0 /* SceneDelegate.swift in Sources */,

--- a/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
+++ b/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		4A8FFA5929C9E1FE00FB76C0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4A8FFA5829C9E1FE00FB76C0 /* Assets.xcassets */; };
 		4A8FFA5C29C9E1FE00FB76C0 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4A8FFA5A29C9E1FE00FB76C0 /* LaunchScreen.storyboard */; };
 		4AC9489829ED800800489C2B /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4AC9489729ED800800489C2B /* GoogleService-Info.plist */; };
+		4AD04B392A190020004B7A58 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD04B382A190020004B7A58 /* UITextField+.swift */; };
 		4AD923E72A0650B600FF5E27 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD923E62A0650B600FF5E27 /* SplashViewController.swift */; };
 		4AD923E92A0692C600FF5E27 /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD923E82A0692C600FF5E27 /* BottomSheetViewController.swift */; };
 		4AD923EB2A0692EA00FF5E27 /* BottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD923EA2A0692EA00FF5E27 /* BottomSheetView.swift */; };
@@ -96,6 +97,7 @@
 		4A8FFA5B29C9E1FE00FB76C0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		4A8FFA5D29C9E1FE00FB76C0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4AC9489729ED800800489C2B /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		4AD04B382A190020004B7A58 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
 		4AD923E62A0650B600FF5E27 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		4AD923E82A0692C600FF5E27 /* BottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewController.swift; sourceTree = "<group>"; };
 		4AD923EA2A0692EA00FF5E27 /* BottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetView.swift; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 				37A574CB29FF990E00312453 /* UIViewController+.swift */,
 				37A574CD29FF9A2D00312453 /* UIScreen+.swift */,
 				37A574CF29FF9AEE00312453 /* UILabel+.swift */,
+				4AD04B382A190020004B7A58 /* UITextField+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -485,6 +488,7 @@
 				4A3F2E9C2A0B4C7100F6AC60 /* AlarmCollectionView.swift in Sources */,
 				4A0EA4572A01403E006CCE52 /* MoyaLoggingPlugin.swift in Sources */,
 				4A0E8D5829F8362E00E0FC23 /* AuthViewController.swift in Sources */,
+				4AD04B392A190020004B7A58 /* UITextField+.swift in Sources */,
 				37A574C829FF6F1C00312453 /* UIView+.swift in Sources */,
 				37A574D029FF9AEE00312453 /* UILabel+.swift in Sources */,
 				37A574CE29FF9A2D00312453 /* UIScreen+.swift in Sources */,

--- a/Smeem-iOS/Smeem-iOS/Global/Extensions/UITextField+.swift
+++ b/Smeem-iOS/Smeem-iOS/Global/Extensions/UITextField+.swift
@@ -1,0 +1,16 @@
+//
+//  UITextField+.swift
+//  Smeem-iOS
+//
+//  Created by 황찬미 on 2023/05/20.
+//
+
+import UIKit
+
+extension UITextField {
+    func addPaddingView() {
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: self.frame.height))
+        self.leftView = paddingView
+        self.leftViewMode = .always
+    }
+}

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Goal/GoalCollectionViewCell.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Goal/GoalCollectionViewCell.swift
@@ -31,6 +31,7 @@ final class GoalCollectionViewCell: UICollectionViewCell {
     private let goalLabel: UILabel = {
         let label = UILabel()
         label.font = .b3
+        label.text = "전체 동의하기"
         label.textColor = .gray600
         return label
     }()

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Nickname/UserNickNameViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Nickname/UserNickNameViewController.swift
@@ -35,6 +35,11 @@ final class UserNicknameViewController: UIViewController {
         textField.tintColor = .point
         textField.textColor = .point
         textField.font = .h3
+        
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: nicknameLimitLabel.frame.height))
+        textField.leftView = paddingView
+        textField.leftViewMode = .always
+        
         return textField
     }()
     

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Nickname/UserNickNameViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Nickname/UserNickNameViewController.swift
@@ -1,0 +1,97 @@
+//
+//  UserNickNameViewController.swift
+//  Smeem-iOS
+//
+//  Created by 황찬미 on 2023/05/17.
+//
+
+import UIKit
+
+final class UserNicknameViewController: UIViewController {
+    
+    // MARK: - Property
+    
+    // MARK: - UI Property
+    
+    private let titleNicknameLabel: UILabel = {
+        let label = UILabel()
+        label.text = "닉네임 설정"
+        label.font = .h2
+        label.textColor = .smeemBlack
+        return label
+    }()
+    
+    private let detailNicknameLabel: UILabel = {
+        let label = UILabel()
+        label.text = "닉네임은 마이페이지에서 수정할 수 있어요."
+        label.font = .b4
+        label.textColor = .smeemBlack
+        return label
+    }()
+    
+    private lazy var nicknameTextField: UITextField = {
+        let textField = UITextField()
+        textField.borderStyle = .roundedRect
+        textField.tintColor = .point
+        return textField
+    }()
+    
+    private let nicknameLimitLabel: UILabel = {
+        let label = UILabel()
+        label.text = "공백 포함 10자 제한"
+        label.font = .c4
+        label.textColor = .gray400
+        return label
+    }()
+    
+    private let nextButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("다음", for: .normal)
+        return button
+    }()
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setBackgroundColor()
+        setLayout()
+        showKeyboard(textView: nicknameTextField)
+    }
+    
+    // MARK: - @objc
+    
+    // MARK: - Custom Method
+    
+    // MARK: - Layout
+    
+    private func setBackgroundColor() {
+        view.backgroundColor = .smeemWhite
+    }
+
+    private func setLayout() {
+        view.addSubviews(titleNicknameLabel, detailNicknameLabel, nicknameTextField, nicknameLimitLabel)
+        
+        titleNicknameLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(120)
+            $0.leading.equalToSuperview().inset(26)
+        }
+        
+        detailNicknameLabel.snp.makeConstraints {
+            $0.top.equalTo(titleNicknameLabel.snp.bottom).offset(6)
+            $0.leading.equalToSuperview().inset(26)
+        }
+        
+        nicknameTextField.snp.makeConstraints {
+            $0.top.equalTo(detailNicknameLabel.snp.bottom).offset(28)
+            $0.leading.trailing.equalToSuperview().inset(26)
+            $0.height.equalTo(convertByHeightRatio(60))
+        }
+        
+        nicknameLimitLabel.snp.makeConstraints {
+            $0.top.equalTo(nicknameTextField.snp.bottom).offset(10)
+            $0.trailing.equalToSuperview().inset(20)
+        }
+    }
+}

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Nickname/UserNickNameViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Nickname/UserNickNameViewController.swift
@@ -35,11 +35,7 @@ final class UserNicknameViewController: UIViewController {
         textField.tintColor = .point
         textField.textColor = .point
         textField.font = .h3
-        
-        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: nicknameLimitLabel.frame.height))
-        textField.leftView = paddingView
-        textField.leftViewMode = .always
-        
+        textField.addPaddingView()
         return textField
     }()
     
@@ -64,12 +60,17 @@ final class UserNicknameViewController: UIViewController {
         
         setBackgroundColor()
         setLayout()
+        setTextFieldDelegate()
         showKeyboard(textView: nicknameTextField)
     }
 
     // MARK: - @objc
     
     // MARK: - Custom Method
+    
+    private func setTextFieldDelegate() {
+        nicknameTextField.delegate = self
+    }
 
     // MARK: - Layout
     
@@ -107,5 +108,21 @@ final class UserNicknameViewController: UIViewController {
             $0.height.equalTo(convertByHeightRatio(60))
             $0.bottom.equalToSuperview().inset(336+10)
         }
+    }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension UserNicknameViewController: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        if let char = string.cString(using: String.Encoding.utf8) {
+               let isBackSpace = strcmp(char, "\\b")
+               if isBackSpace == -92 {
+                   return true
+               }
+         }
+        
+        guard self.nicknameTextField.text?.count ?? 0 < 10 else { return false }
+        return true
     }
 }

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Nickname/UserNickNameViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Nickname/UserNickNameViewController.swift
@@ -33,6 +33,8 @@ final class UserNicknameViewController: UIViewController {
         let textField = UITextField()
         textField.borderStyle = .roundedRect
         textField.tintColor = .point
+        textField.textColor = .point
+        textField.font = .h3
         return textField
     }()
     
@@ -44,8 +46,8 @@ final class UserNicknameViewController: UIViewController {
         return label
     }()
     
-    private let nextButton: UIButton = {
-        let button = UIButton()
+    private let nextButton: SmeemButton = {
+        let button = SmeemButton()
         button.setTitle("다음", for: .normal)
         return button
     }()
@@ -59,11 +61,11 @@ final class UserNicknameViewController: UIViewController {
         setLayout()
         showKeyboard(textView: nicknameTextField)
     }
-    
+
     // MARK: - @objc
     
     // MARK: - Custom Method
-    
+
     // MARK: - Layout
     
     private func setBackgroundColor() {
@@ -71,7 +73,8 @@ final class UserNicknameViewController: UIViewController {
     }
 
     private func setLayout() {
-        view.addSubviews(titleNicknameLabel, detailNicknameLabel, nicknameTextField, nicknameLimitLabel)
+        view.addSubviews(titleNicknameLabel, detailNicknameLabel, nicknameTextField, nicknameLimitLabel,
+                         nextButton)
         
         titleNicknameLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(120)
@@ -92,6 +95,12 @@ final class UserNicknameViewController: UIViewController {
         nicknameLimitLabel.snp.makeConstraints {
             $0.top.equalTo(nicknameTextField.snp.bottom).offset(10)
             $0.trailing.equalToSuperview().inset(20)
+        }
+        
+        nextButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(18)
+            $0.height.equalTo(convertByHeightRatio(60))
+            $0.bottom.equalToSuperview().inset(336+10)
         }
     }
 }

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Service/ServiceAcceptCollectionViewCell.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Service/ServiceAcceptCollectionViewCell.swift
@@ -1,0 +1,69 @@
+//
+//  ServiceAcceptCollectionViewCell.swift
+//  Smeem-iOS
+//
+//  Created by 황찬미 on 2023/05/17.
+//
+
+import UIKit
+
+final class ServiceAcceptCollectionViewCell: UICollectionViewCell {
+    
+    static let identifier = "ServiceAcceptCollectionViewCell"
+    
+    // MARK: - Property
+    
+    // MARK: - UI Property
+    
+    private let checkButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .point
+        return button
+    }()
+    
+    private let serviceAcceptLabel: UILabel = {
+        let label = UILabel()
+        label.font = .b4
+        label.setTextWithLineHeight(lineHeight: 22)
+        label.textColor = .smeemBlack
+        return label
+    }()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - @objc
+    
+    // MARK: - Custom Method
+    
+    func setData(_ text: String) {
+        serviceAcceptLabel.text = text
+    }
+    
+    // MARK: - Layout
+    
+    private func setLayout() {
+        addSubviews(checkButton, serviceAcceptLabel)
+        
+        checkButton.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalToSuperview()
+            $0.height.width.equalTo(20)
+        }
+        
+        serviceAcceptLabel.snp.makeConstraints {
+            $0.leading.equalTo(checkButton.snp.trailing).offset(12)
+            $0.top.equalToSuperview()
+        }
+    }
+
+}

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Service/ServiceAcceptViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Service/ServiceAcceptViewController.swift
@@ -1,0 +1,172 @@
+//
+//  ServiceAcceptViewController.swift
+//  Smeem-iOS
+//
+//  Created by 황찬미 on 2023/05/17.
+//
+
+import UIKit
+
+final class ServiceAcceptViewController: UIViewController {
+    
+    // MARK: - Property
+    
+    let serviceAccptArray = ["[필수] 서비스 이용약관", "[필수] 개인정보 수집 및 이용 동의",
+                             "[필수] 위치기반 서비스 이용약관 동의", "[선택] 마케팅 정보 활용 동의"]
+    
+    // MARK: - UI Property
+    
+    private let titleServiceLabel: UILabel = {
+        let label = UILabel()
+        label.text = "서비스 이용약관"
+        label.font = .h2
+        label.textColor = .smeemBlack
+        return label
+    }()
+    
+    private let detailServiceLabel: UILabel = {
+        let label = UILabel()
+        label.text = "서비스 이용을 위해 약관에 동의해주세요."
+        label.font = .b4
+        label.textColor = .smeemBlack
+        return label
+    }()
+    
+    private let serviceCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = .clear
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.allowsMultipleSelection = true
+        return collectionView
+    }()
+    
+    private let nextButton: SmeemButton = {
+        let button = SmeemButton()
+        button.setTitle("다음", for: .normal)
+        return button
+    }()
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setBackgroundColor()
+        setLayout()
+        setDelegate()
+        setCellRegister()
+    }
+    
+    // MARK: - @objc
+    
+    // MARK: - Custom Method
+    
+    private func setDelegate() {
+        serviceCollectionView.delegate = self
+        serviceCollectionView.dataSource = self
+    }
+    
+    private func setCellRegister() {
+        serviceCollectionView.register(GoalCollectionViewCell.self, forCellWithReuseIdentifier: GoalCollectionViewCell.identifier)
+        serviceCollectionView.register(ServiceAcceptCollectionViewCell.self, forCellWithReuseIdentifier: ServiceAcceptCollectionViewCell.identifier)
+    }
+    
+    // MARK: - Layout
+    
+    private func setBackgroundColor() {
+        view.backgroundColor = .smeemWhite
+    }
+    
+    private func setLayout() {
+        view.addSubviews(titleServiceLabel, detailServiceLabel, serviceCollectionView, nextButton)
+        
+        titleServiceLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(120)
+            $0.leading.equalToSuperview().inset(26)
+        }
+        
+        detailServiceLabel.snp.makeConstraints {
+            $0.top.equalTo(titleServiceLabel.snp.bottom).offset(6)
+            $0.leading.equalToSuperview().inset(26)
+        }
+        
+        serviceCollectionView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(18)
+            $0.top.equalTo(detailServiceLabel.snp.bottom).offset(28)
+            $0.bottom.equalToSuperview()
+        }
+        
+        nextButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(18)
+            $0.bottom.equalToSuperview().inset(50)
+            $0.height.equalTo(convertByHeightRatio(60))
+        }
+    }
+}
+
+// MARK: - UICollectionViewDelegate
+
+extension ServiceAcceptViewController: UICollectionViewDelegate { }
+
+// MARK: - UICollectionViewDataSource
+
+extension ServiceAcceptViewController: UICollectionViewDataSource {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        let sectionNumber = 2
+        return sectionNumber
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        let firstSectionItemsNumber = 1
+        let secondSectionItemsNumber = 4
+        
+        if section == 0 {
+            return firstSectionItemsNumber
+        } else {
+            return secondSectionItemsNumber
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        if indexPath.section == 0 {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: GoalCollectionViewCell.identifier, for: indexPath) as? GoalCollectionViewCell else { return UICollectionViewCell() }
+            return cell
+        } else {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ServiceAcceptCollectionViewCell.identifier, for: indexPath) as? ServiceAcceptCollectionViewCell else { return UICollectionViewCell() }
+            cell.setData(serviceAccptArray[indexPath.item])
+            return cell
+        }
+    }
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension ServiceAcceptViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        if indexPath.section == 0 {
+            let width = collectionView.frame.width
+            let height = convertByHeightRatio(60)
+            return CGSize(width: width, height: height)
+        } else {
+            let width = collectionView.frame.width
+            let height = convertByHeightRatio(20)
+            return CGSize(width: width, height: height)
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        if section == 1 {
+            let sectionLineSpacing: CGFloat = 32
+            return sectionLineSpacing
+        }
+        return CGFloat()
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        if section == 1 {
+            return UIEdgeInsets(top: 32, left: 0, bottom: 0, right: 0)
+        }
+        return UIEdgeInsets()
+    }
+}


### PR DESCRIPTION
##  작업한 내용
- 닉네임 설정 및 서비스 이용약관 UI 구현했어요

##  PR Point
- 닉네임 중복을 관련된 로직은 추가로 API가 생성될 예정인 것 같아 아직 구현 안 해 뒀습니다.
- 서비스 이용약관 동의 UI에서 전체 동의하기 버튼은 목표 설정 UI에서 사용했던 cell 가져와서 사용했구요. 밑에 필수, 선택 괄호 버튼들은 하나의 section을 더 만들어서 구현했습니다. 첫번째 cell 눌렀을 때 밑에 버튼들이 전부 다 선택이 되어야 하는데요. 어느 영역을 눌러야 버튼이 활성화되는지 조금 애매한 것 같아서 디쟌이랑 의논해 보고 버튼 활성화랑 같이 다음 브랜치에서 작업할게요~

## 스크린샷

|닉네임 설정|서비스 이용약관|
|------|---|
|![image](https://github.com/Team-Smeme/Smeem-iOS/assets/86944161/5264e1dc-50c9-4104-a911-85251b81fb32)|![Simulator Screen Recording - iPhone 13 mini - 2023-05-18 at 00 28 50](https://github.com/Team-Smeme/Smeem-iOS/assets/86944161/1bedf737-fbdb-42da-a07b-44439351c100)|

## 관련 이슈

- Resolved: #24
