### PR TITLE
[Feat] #24 - 첨삭 일기 UI

### DIFF
--- a/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
+++ b/Smeem-iOS/Smeem-iOS.xcodeproj/project.pbxproj
@@ -48,6 +48,9 @@
 		4A8FFA5C29C9E1FE00FB76C0 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4A8FFA5A29C9E1FE00FB76C0 /* LaunchScreen.storyboard */; };
 		4AC9489829ED800800489C2B /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4AC9489729ED800800489C2B /* GoogleService-Info.plist */; };
 		4AD04B392A190020004B7A58 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD04B382A190020004B7A58 /* UITextField+.swift */; };
+		4AD04B3B2A1905BB004B7A58 /* DiaryScrollerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD04B3A2A1905BB004B7A58 /* DiaryScrollerView.swift */; };
+		4AD04B3D2A190E9A004B7A58 /* UITextView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD04B3C2A190E9A004B7A58 /* UITextView+.swift */; };
+		4AD04B402A1921AE004B7A58 /* CorrectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD04B3F2A1921AE004B7A58 /* CorrectionViewController.swift */; };
 		4AD923E72A0650B600FF5E27 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD923E62A0650B600FF5E27 /* SplashViewController.swift */; };
 		4AD923E92A0692C600FF5E27 /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD923E82A0692C600FF5E27 /* BottomSheetViewController.swift */; };
 		4AD923EB2A0692EA00FF5E27 /* BottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD923EA2A0692EA00FF5E27 /* BottomSheetView.swift */; };
@@ -98,6 +101,9 @@
 		4A8FFA5D29C9E1FE00FB76C0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4AC9489729ED800800489C2B /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		4AD04B382A190020004B7A58 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
+		4AD04B3A2A1905BB004B7A58 /* DiaryScrollerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryScrollerView.swift; sourceTree = "<group>"; };
+		4AD04B3C2A190E9A004B7A58 /* UITextView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+.swift"; sourceTree = "<group>"; };
+		4AD04B3F2A1921AE004B7A58 /* CorrectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionViewController.swift; sourceTree = "<group>"; };
 		4AD923E62A0650B600FF5E27 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		4AD923E82A0692C600FF5E27 /* BottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewController.swift; sourceTree = "<group>"; };
 		4AD923EA2A0692EA00FF5E27 /* BottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetView.swift; sourceTree = "<group>"; };
@@ -144,6 +150,7 @@
 				4AF5076F2A10CBA2007C62B1 /* Onboarding */,
 				4AE4B5172A06BF4A00D45F87 /* BottomSheet */,
 				6F62668A2A04E889000365CD /* Home */,
+				4AD04B3E2A19217B004B7A58 /* Correction */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -157,6 +164,7 @@
 				37A574CD29FF9A2D00312453 /* UIScreen+.swift */,
 				37A574CF29FF9AEE00312453 /* UILabel+.swift */,
 				4AD04B382A190020004B7A58 /* UITextField+.swift */,
+				4AD04B3C2A190E9A004B7A58 /* UITextView+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -169,6 +177,7 @@
 				37A574E52A02178D00312453 /* CustomToastView.swift */,
 				37A574E72A02424F00312453 /* RandomSubjectView.swift */,
 				4AEFD4C92A1392DF00DAB2BD /* HowLearningView.swift */,
+				4AD04B3A2A1905BB004B7A58 /* DiaryScrollerView.swift */,
 			);
 			path = UIComponents;
 			sourceTree = "<group>";
@@ -314,6 +323,14 @@
 				37A574BC29FE224700312453 /* Supports */,
 			);
 			path = "Smeem-iOS";
+			sourceTree = "<group>";
+		};
+		4AD04B3E2A19217B004B7A58 /* Correction */ = {
+			isa = PBXGroup;
+			children = (
+				4AD04B3F2A1921AE004B7A58 /* CorrectionViewController.swift */,
+			);
+			path = Correction;
 			sourceTree = "<group>";
 		};
 		4AD923E52A0650A000FF5E27 /* Splash */ = {
@@ -482,9 +499,11 @@
 				37A574CC29FF990E00312453 /* UIViewController+.swift in Sources */,
 				37A574C329FF6E9C00312453 /* ImageLiterals.swift in Sources */,
 				4A3F2EA02A0C18B600F6AC60 /* DatePickerFooterView.swift in Sources */,
+				4AD04B3D2A190E9A004B7A58 /* UITextView+.swift in Sources */,
 				4A0EA4622A01413D006CCE52 /* DataModel.swift in Sources */,
 				4A3F2E972A0ABBAA00F6AC60 /* AlarmCollectionViewCell.swift in Sources */,
 				6F62668C2A04EA3B000365CD /* HomeViewController.swift in Sources */,
+				4AD04B3B2A1905BB004B7A58 /* DiaryScrollerView.swift in Sources */,
 				4A3F2E9C2A0B4C7100F6AC60 /* AlarmCollectionView.swift in Sources */,
 				4A0EA4572A01403E006CCE52 /* MoyaLoggingPlugin.swift in Sources */,
 				4A0E8D5829F8362E00E0FC23 /* AuthViewController.swift in Sources */,
@@ -494,6 +513,7 @@
 				37A574CE29FF9A2D00312453 /* UIScreen+.swift in Sources */,
 				4A0EA4602A014139006CCE52 /* Service.swift in Sources */,
 				4A0EA4592A014103006CCE52 /* URLConstant.swift in Sources */,
+				4AD04B402A1921AE004B7A58 /* CorrectionViewController.swift in Sources */,
 				4A8275D32A1513120083A4AB /* ServiceAcceptViewController.swift in Sources */,
 				4AD923E72A0650B600FF5E27 /* SplashViewController.swift in Sources */,
 				4AD923EB2A0692EA00FF5E27 /* BottomSheetView.swift in Sources */,

--- a/Smeem-iOS/Smeem-iOS/Global/Extensions/UILabel+.swift
+++ b/Smeem-iOS/Smeem-iOS/Global/Extensions/UILabel+.swift
@@ -29,26 +29,19 @@ extension UILabel {
     
     /// UILabel의 line 수 길이 구하는 함수
     func countCurrentLines() -> CGFloat {
-        guard let text = self.text as NSString? else { return 0 }
-        guard let font = self.font              else { return 0 }
+        let myText = text as? NSString
+
+        let labelSize = myText?.boundingRect(with: CGSize(width: self.frame.width, height: .greatestFiniteMagnitude),
+                                             options: .usesLineFragmentOrigin,
+                                             attributes: [NSAttributedString.Key.font: font ?? UIFont()],
+                                             context: nil)
         
-        var attributes = [NSAttributedString.Key: Any]()
-        
-        if let kernAttribute = self.attributedText?.attributes(at: 0, effectiveRange: nil).first(where: { key, _ in
-            return key == .kern
-        }) {
-            attributes[.kern] = kernAttribute.value
-        }
-        attributes[.font] = font
-        
-        let labelTextSize = text.boundingRect(
-            with: CGSize(width: self.bounds.width, height: .greatestFiniteMagnitude),
-            options: .usesLineFragmentOrigin,
-            attributes: attributes,
-            context: nil
-        )
-        
-        return CGFloat(ceil(labelTextSize.height / font.lineHeight))
+        return ceil(CGFloat((labelSize?.height ?? 0) / font.lineHeight))
+    }
+    
+    func calculateContentHeight(lineHeight: CGFloat) -> CGFloat {
+        let numberOfLines = self.countCurrentLines()
+        return numberOfLines * lineHeight
     }
     
     /**
@@ -61,11 +54,11 @@ extension UILabel {
      let currentHeight = label.calculateContentHeight(21)
      ~~~
      */
-    func calculateContentHeight(lineHeight: CGFloat) -> CGFloat {
-        let numOfLines = self.countCurrentLines()
-        
-        return numOfLines * lineHeight
-    }
+//    func calculateContentHeight(lineHeight: CGFloat) -> CGFloat {
+//        let numOfLines = self.countCurrentLines()
+//        
+//        return numOfLines * lineHeight
+//    }
     
     func asColor(targetString: String, color: UIColor) {
         let fullText = text ?? ""

--- a/Smeem-iOS/Smeem-iOS/Global/Extensions/UILabel+.swift
+++ b/Smeem-iOS/Smeem-iOS/Global/Extensions/UILabel+.swift
@@ -39,11 +39,6 @@ extension UILabel {
         return ceil(CGFloat((labelSize?.height ?? 0) / font.lineHeight))
     }
     
-    func calculateContentHeight(lineHeight: CGFloat) -> CGFloat {
-        let numberOfLines = self.countCurrentLines()
-        return numberOfLines * lineHeight
-    }
-    
     /**
      custom line height가 적용된 label height를 구하는 함수
      - Parameters:
@@ -54,11 +49,12 @@ extension UILabel {
      let currentHeight = label.calculateContentHeight(21)
      ~~~
      */
-//    func calculateContentHeight(lineHeight: CGFloat) -> CGFloat {
-//        let numOfLines = self.countCurrentLines()
-//        
-//        return numOfLines * lineHeight
-//    }
+    
+    func calculateContentHeight(lineHeight: CGFloat) -> CGFloat {
+        let numberOfLines = self.countCurrentLines()
+        
+        return numberOfLines * lineHeight
+    }
     
     func asColor(targetString: String, color: UIColor) {
         let fullText = text ?? ""

--- a/Smeem-iOS/Smeem-iOS/Global/Extensions/UITextView+.swift
+++ b/Smeem-iOS/Smeem-iOS/Global/Extensions/UITextView+.swift
@@ -1,0 +1,22 @@
+//
+//  UITextView+.swift
+//  Smeem-iOS
+//
+//  Created by 황찬미 on 2023/05/20.
+//
+
+import UIKit
+
+extension UITextView {
+    func setLineSpacing() {
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = 2.5
+        let attributes = [
+            NSAttributedString.Key.paragraphStyle: style,
+            NSAttributedString.Key.font: UIFont.b4
+        ]
+        self.textAlignment = .left
+        self.sizeToFit()
+        self.attributedText = NSAttributedString(string: self.text, attributes: attributes)
+    }
+}

--- a/Smeem-iOS/Smeem-iOS/Global/UIComponents/DiaryScrollerView.swift
+++ b/Smeem-iOS/Smeem-iOS/Global/UIComponents/DiaryScrollerView.swift
@@ -1,0 +1,202 @@
+//
+//  DiaryScrollerView.swift
+//  Smeem-iOS
+//
+//  Created by 황찬미 on 2023/05/20.
+//
+
+/**
+ 1. VC에서 생성시 type 정해 주기. 첨삭 일기일 경우 .correction, 랜덤 주제가 있을 경우 correctionHasRandomSubject
+ 그냥 일기 상세일 경우 detailDiary, 랜덤 주제 있을 경우 detatilDiaryHasRandomSubject
+ 
+ private let diaryScrollerView: DiaryScrollerView = {
+     let scrollerView = DiaryScrollerView()
+     scrollerView.viewType = .detailDiary
+     return scrollerView
+ }()
+ 
+ 2. 일기 줄수의 높이에 따라 내부 contentView의 높이가 동적으로 계산되기 때문에, 레이아웃만 설정해 주면 됨.
+ 
+ diaryScrollerView.snp.makeConstraints {
+     $0.top.leading.trailing.bottom.equalToSuperview()
+ }
+ */
+
+import UIKit
+
+final class DiaryScrollerView: UIScrollView {
+    
+    // MARK: - Property
+    
+    enum ViewType {
+        case correction
+        case correctionHasRandomSubject
+        case detailDiary
+        case detailDiaryHasRandomSubject
+    }
+    
+    var viewType: ViewType = .correction {
+        didSet {
+            viewTypeContentViewLayout()
+        }
+    }
+    
+    // MARK: - UI Property
+    
+    private let contentView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .point
+        return view
+    }()
+    
+    private let correnctionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "TIP 첨삭할 부분을 드래그 해보세요!"
+        label.font = .c3
+        label.textColor = .point
+        label.asColor(targetString: "첨삭할 부분을 드래그 해보세요!", color: .gray500)
+        return label
+    }()
+    
+    private let contentLabel: UITextView = {
+        let textView = UITextView()
+        textView.textColor = .black
+        textView.font = .b4
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.text = "I watched Avatar with my boyfriend at Hongdae CGV. I should have skimmed the previous season - Avatar1.. I really couldn’t get what they were saying and the universe(??). What I was annoyed then was 두팔 didn’t know that as me. I think 두팔 who is my boyfriend should study before wathcing…. but Avatar2 is amazing movie I think. In my personal opinion, the jjin main character of Avatar2 is not Sully, but his son."
+        textView.setLineSpacing()
+        return textView
+    }()
+    
+    private let dateLabel: UILabel = {
+        let label = UILabel()
+        label.text = "2023년 3월 27일 4:18 PM"
+        label.font = .c3
+        label.textColor = .gray500
+        return label
+    }()
+    
+    private let nicknameLabel: UILabel = {
+        let label = UILabel()
+        label.text = "유진이"
+        label.font = .c3
+        label.textColor = .black
+        return label
+    }()
+    
+    private let labelStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.distribution = .fillEqually
+        stackView.spacing = 4
+        stackView.alignment = .trailing
+        return stackView
+    }()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setLayout()
+        setBackgroundColor()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - @objc
+    
+    // MARK: - Custom Method
+    
+    private func calculateTextViewHeight(textView: UITextView) -> CGFloat {
+        textView.frame = CGRect(x: 0,
+                                y: 0,
+                                width: 339,
+                                height: CGFloat.greatestFiniteMagnitude)
+        
+        let fixedWidth = textView.frame.size.width
+        let newSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
+        textView.frame.size.height = newSize.height
+        
+        return ceil(newSize.height)
+    }
+    
+    private func viewTypeContentViewLayout() {
+        let detailDiaryTopInset: CGFloat = 16
+        let detailbottomInset: CGFloat = 78
+        let correctionTopInset: CGFloat = 46
+        let correctionbottomInset: CGFloat = 68
+        
+        let detailDiaryTotalContentViewHeight = detailDiaryTopInset+detailbottomInset+calculateTextViewHeight(textView: contentLabel)
+        let correctiontextViewTotalHeight = correctionTopInset+correctionbottomInset+calculateTextViewHeight(textView: contentLabel)
+        
+        addSubview(contentView)
+        
+        contentView.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalTo(self.contentLayoutGuide)
+            $0.width.equalToSuperview()
+        }
+        
+        switch viewType {
+        case .correction:
+            contentView.snp.makeConstraints {
+                $0.height.equalTo(correctiontextViewTotalHeight)
+            }
+            
+        case .correctionHasRandomSubject:
+            // 랜덤 주제 추가된 레이아웃으로 수정
+            contentView.snp.makeConstraints {
+                $0.height.equalTo(correctiontextViewTotalHeight)
+            }
+        case .detailDiary:
+            correnctionLabel.isHidden = true
+            
+            contentView.snp.makeConstraints {
+                $0.height.equalTo(detailDiaryTotalContentViewHeight)
+            }
+            
+            contentLabel.snp.makeConstraints {
+                $0.top.equalToSuperview().inset(16)
+            }
+            
+        case .detailDiaryHasRandomSubject:
+            correnctionLabel.isHidden = true
+            
+            // 랜덤 주제 추가된 레이아웃으로 수정
+            contentView.snp.makeConstraints {
+                $0.height.equalTo(detailDiaryTotalContentViewHeight)
+            }
+        }
+        
+    }
+    
+    // MARK: - Layout
+    
+    private func setBackgroundColor() {
+        backgroundColor = .white
+    }
+    
+    private func setLayout() {
+        contentView.addSubviews(correnctionLabel, contentLabel, labelStackView)
+        labelStackView.addArrangedSubviews(dateLabel, nicknameLabel)
+        
+        correnctionLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(13)
+            $0.leading.equalToSuperview().inset(20)
+        }
+        
+        contentLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(36)
+            $0.leading.trailing.equalToSuperview().inset(18)
+        }
+
+        labelStackView.snp.makeConstraints {
+            $0.top.equalTo(contentLabel.snp.bottom).offset(24)
+            $0.trailing.equalToSuperview().inset(18)
+        }
+    }
+
+}

--- a/Smeem-iOS/Smeem-iOS/Global/UIComponents/DiaryScrollerView.swift
+++ b/Smeem-iOS/Smeem-iOS/Global/UIComponents/DiaryScrollerView.swift
@@ -43,11 +43,7 @@ final class DiaryScrollerView: UIScrollView {
     
     // MARK: - UI Property
     
-    private let contentView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .point
-        return view
-    }()
+    private let contentView = UIView()
     
     private let correnctionLabel: UILabel = {
         let label = UILabel()
@@ -99,7 +95,6 @@ final class DiaryScrollerView: UIScrollView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        setLayout()
         setBackgroundColor()
     }
     
@@ -124,26 +119,45 @@ final class DiaryScrollerView: UIScrollView {
         return ceil(newSize.height)
     }
     
+    
+    // MARK: - Layout
+    
+    private func setBackgroundColor() {
+        backgroundColor = .white
+    }
+    
     private func viewTypeContentViewLayout() {
         let detailDiaryTopInset: CGFloat = 16
         let detailbottomInset: CGFloat = 78
-        let correctionTopInset: CGFloat = 46
-        let correctionbottomInset: CGFloat = 68
+        let correctionTopInset: CGFloat = 41
+        let correctionbottomInset: CGFloat = 78
         
         let detailDiaryTotalContentViewHeight = detailDiaryTopInset+detailbottomInset+calculateTextViewHeight(textView: contentLabel)
         let correctiontextViewTotalHeight = correctionTopInset+correctionbottomInset+calculateTextViewHeight(textView: contentLabel)
         
         addSubview(contentView)
+        contentView.addSubviews(correnctionLabel, contentLabel, labelStackView)
+        labelStackView.addArrangedSubviews(dateLabel, nicknameLabel)
         
         contentView.snp.makeConstraints {
             $0.top.leading.trailing.bottom.equalTo(self.contentLayoutGuide)
             $0.width.equalToSuperview()
         }
         
+        correnctionLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(8)
+            $0.leading.equalToSuperview().inset(20)
+        }
+        
         switch viewType {
         case .correction:
             contentView.snp.makeConstraints {
                 $0.height.equalTo(correctiontextViewTotalHeight)
+            }
+            
+            contentLabel.snp.makeConstraints {
+                $0.top.equalTo(correnctionLabel.snp.bottom).offset(6)
+                $0.leading.trailing.equalToSuperview().inset(18)
             }
             
         case .correctionHasRandomSubject:
@@ -160,6 +174,7 @@ final class DiaryScrollerView: UIScrollView {
             
             contentLabel.snp.makeConstraints {
                 $0.top.equalToSuperview().inset(16)
+                $0.leading.trailing.equalToSuperview().inset(18)
             }
             
         case .detailDiaryHasRandomSubject:
@@ -170,33 +185,12 @@ final class DiaryScrollerView: UIScrollView {
                 $0.height.equalTo(detailDiaryTotalContentViewHeight)
             }
         }
-        
-    }
-    
-    // MARK: - Layout
-    
-    private func setBackgroundColor() {
-        backgroundColor = .white
-    }
-    
-    private func setLayout() {
-        contentView.addSubviews(correnctionLabel, contentLabel, labelStackView)
-        labelStackView.addArrangedSubviews(dateLabel, nicknameLabel)
-        
-        correnctionLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(13)
-            $0.leading.equalToSuperview().inset(20)
-        }
-        
-        contentLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(36)
-            $0.leading.trailing.equalToSuperview().inset(18)
-        }
 
         labelStackView.snp.makeConstraints {
             $0.top.equalTo(contentLabel.snp.bottom).offset(24)
             $0.trailing.equalToSuperview().inset(18)
         }
+        
     }
 
 }

--- a/Smeem-iOS/Smeem-iOS/Global/UIComponents/DiaryScrollerView.swift
+++ b/Smeem-iOS/Smeem-iOS/Global/UIComponents/DiaryScrollerView.swift
@@ -38,6 +38,7 @@ final class DiaryScrollerView: UIScrollView {
     var viewType: ViewType = .correction {
         didSet {
             viewTypeContentViewLayout()
+            setDelegate()
         }
     }
     
@@ -61,6 +62,7 @@ final class DiaryScrollerView: UIScrollView {
         textView.isEditable = false
         textView.isScrollEnabled = false
         textView.text = "I watched Avatar with my boyfriend at Hongdae CGV. I should have skimmed the previous season - Avatar1.. I really couldn’t get what they were saying and the universe(??). What I was annoyed then was 두팔 didn’t know that as me. I think 두팔 who is my boyfriend should study before wathcing…. but Avatar2 is amazing movie I think. In my personal opinion, the jjin main character of Avatar2 is not Sully, but his son."
+        textView.tintColor = .point
         textView.setLineSpacing()
         return textView
     }()
@@ -119,47 +121,54 @@ final class DiaryScrollerView: UIScrollView {
         return ceil(newSize.height)
     }
     
-    
-    // MARK: - Layout
-    
+    private func setDelegate() {
+        switch viewType {
+        case .correction, .correctionHasRandomSubject:
+            contentLabel.delegate = self
+        case .detailDiary, .detailDiaryHasRandomSubject: break
+        }
+    }
+        
+        // MARK: - Layout
+        
     private func setBackgroundColor() {
         backgroundColor = .white
     }
-    
+        
     private func viewTypeContentViewLayout() {
         let detailDiaryTopInset: CGFloat = 16
         let detailbottomInset: CGFloat = 78
         let correctionTopInset: CGFloat = 41
         let correctionbottomInset: CGFloat = 78
-        
+            
         let detailDiaryTotalContentViewHeight = detailDiaryTopInset+detailbottomInset+calculateTextViewHeight(textView: contentLabel)
         let correctiontextViewTotalHeight = correctionTopInset+correctionbottomInset+calculateTextViewHeight(textView: contentLabel)
-        
+            
         addSubview(contentView)
         contentView.addSubviews(correnctionLabel, contentLabel, labelStackView)
         labelStackView.addArrangedSubviews(dateLabel, nicknameLabel)
-        
+            
         contentView.snp.makeConstraints {
             $0.top.leading.trailing.bottom.equalTo(self.contentLayoutGuide)
             $0.width.equalToSuperview()
         }
-        
+            
         correnctionLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(8)
             $0.leading.equalToSuperview().inset(20)
         }
-        
+            
         switch viewType {
         case .correction:
             contentView.snp.makeConstraints {
                 $0.height.equalTo(correctiontextViewTotalHeight)
             }
-            
+                
             contentLabel.snp.makeConstraints {
                 $0.top.equalTo(correnctionLabel.snp.bottom).offset(6)
                 $0.leading.trailing.equalToSuperview().inset(18)
             }
-            
+                
         case .correctionHasRandomSubject:
             // 랜덤 주제 추가된 레이아웃으로 수정
             contentView.snp.makeConstraints {
@@ -167,30 +176,44 @@ final class DiaryScrollerView: UIScrollView {
             }
         case .detailDiary:
             correnctionLabel.isHidden = true
-            
+                
             contentView.snp.makeConstraints {
                 $0.height.equalTo(detailDiaryTotalContentViewHeight)
             }
-            
+                
             contentLabel.snp.makeConstraints {
                 $0.top.equalToSuperview().inset(16)
                 $0.leading.trailing.equalToSuperview().inset(18)
             }
-            
+                
         case .detailDiaryHasRandomSubject:
             correnctionLabel.isHidden = true
-            
+                
             // 랜덤 주제 추가된 레이아웃으로 수정
             contentView.snp.makeConstraints {
                 $0.height.equalTo(detailDiaryTotalContentViewHeight)
             }
         }
-
+            
         labelStackView.snp.makeConstraints {
             $0.top.equalTo(contentLabel.snp.bottom).offset(24)
             $0.trailing.equalToSuperview().inset(18)
         }
-        
     }
+}
 
+extension DiaryScrollerView: UITextViewDelegate {
+    func textView(_ textView: UITextView,
+                  editMenuForTextIn range: NSRange,
+                  suggestedActions: [UIMenuElement]) -> UIMenu? {
+        var additionalActions: [UIMenuElement] = []
+        
+        if range.length > 0 {
+            let chanmiAction = UIAction(title: "첨삭") {_ in
+                print(textView.text(in: textView.selectedTextRange ?? UITextRange()) ?? String())
+            }
+            additionalActions.append(chanmiAction)
+        }
+        return UIMenu(children: additionalActions)
+    }
 }

--- a/Smeem-iOS/Smeem-iOS/Presentation/Correction/CorrectionViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Correction/CorrectionViewController.swift
@@ -1,0 +1,83 @@
+//
+//  CorrectionViewController.swift
+//  Smeem-iOS
+//
+//  Created by 황찬미 on 2023/05/21.
+//
+
+import UIKit
+
+final class CorrectionViewController: UIViewController {
+    
+    // MARK: - Property
+    
+    // MARK: - UI Property
+    
+    private let naviView = UIView()
+    
+    private let backButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .point
+        return button
+    }()
+    
+    private let editButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .point
+        return button
+    }()
+    
+    private let diaryScrollerView: DiaryScrollerView = {
+        let scrollerView = DiaryScrollerView()
+        scrollerView.viewType = .detailDiary
+        return scrollerView
+    }()
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setBackgroundColor()
+        setLayout()
+    }
+    
+    // MARK: - @objc
+    
+    // MARK: - Custom Method
+    
+    private func setBackgroundColor() {
+        view.backgroundColor = .white
+    }
+    
+    private func setLayout() {
+        view.addSubviews(naviView, diaryScrollerView)
+        naviView.addSubviews(backButton, editButton)
+        
+        naviView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(44)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(66)
+        }
+        
+        backButton.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(12)
+            $0.centerY.equalToSuperview()
+            $0.height.width.equalTo(40)
+        }
+        
+        editButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(18)
+            $0.centerY.equalToSuperview()
+            $0.height.width.equalTo(40)
+        }
+        
+        diaryScrollerView.snp.makeConstraints {
+            $0.top.equalTo(naviView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+
+    
+    // MARK: - Layout
+}


### PR DESCRIPTION
##  작업한 내용
- 첨삭 일기 UI
- diary scroller view

##  PR Point
- 첨삭 일기 UI 구현했어요.
- 일기 textView의 높이를 계산하고, inset, offset값을 더해서 scrollerView의 높이가 동적으로 계산되도록 했어요.
- 그과정에서 UILabel extension에 있는 label 줄 수에 따른 높이 구하는 메서드 조금 수정했습니다~ 기능은 똑같은데 좀 더 간결하게 수정했어요.
- 일기 상세 UI에서 쓰일 scroller view 구현했어요. 사용 방법 문서화해 두었습니다. 첨삭 스크롤뷰, 랜덤 주제 포함된 첨삭 스크롤뷰, 일반 일기 상세 스크롤뷰, 일반 일기 랜덤 주제 포함된 스크롤뷰별로 레이아웃 따로 잡아 두었어요. 뷰컨에서 선언해서 사용할 때 상황에 맞는 타입에 접근하여 사용하면 돼요.
- 랜덤 주제가 수정 사항이 필요할 것 같아요~ 상세 일기 버전으로 된 랜덤 주제가 추가로 필요할 것 같습니다! 완성되면 랜덤 주제 포함된 레이아웃 수정할게요

## 스크린샷

|뷰|설명|
|------|---|
|![image](https://github.com/Team-Smeme/Smeem-iOS/assets/86944161/94afc831-f2da-4cb2-8e96-a72f82f2d56e)|![Simulator Screen Recording - iPhone 13 mini - 2023-05-28 at 22 18 54](https://github.com/Team-Smeme/Smeem-iOS/assets/86944161/295ba558-1da0-47f7-bd96-c128d96bab02) |

## 관련 이슈

- Resolved: #24 
