### PR TITLE
[Feat] #98 - 베타 테스트 버전 로그인 API 수정사항에 맞게 모델 변경 및 플로우 수정

### DIFF
--- a/Smeem-iOS/Smeem-iOS/Global/Constants/UserDefaultsManager.swift
+++ b/Smeem-iOS/Smeem-iOS/Global/Constants/UserDefaultsManager.swift
@@ -37,4 +37,9 @@ struct UserDefaultsManager {
         get { return UserDefaults.standard.bool(forKey: "isShownWelcomeBadgePopup")}
         set { UserDefaults.standard.set(newValue, forKey: "isShownWelcomeBadgePopup")}
     }
+    
+    static var fcmToken: String {
+        get { return UserDefaults.standard.string(forKey: "fcmToken") ?? ""}
+        set { UserDefaults.standard.set(newValue, forKey: "fcmToken")}
+    }
 }

--- a/Smeem-iOS/Smeem-iOS/Global/UIComponents/Diary/DiaryDetailRandomSubjectView.swift
+++ b/Smeem-iOS/Smeem-iOS/Global/UIComponents/Diary/DiaryDetailRandomSubjectView.swift
@@ -61,7 +61,6 @@ final class DiaryDetailRandomSubjectView: UIView {
         
         if let heightConstraint = heightConstraint {
             let newHeight: CGFloat = contentLabelHeight <= 22 ? 62 : contentLabelHeight + 40
-            print(newHeight, "그치???")
             heightConstraint.update(offset: newHeight)
         }
         

--- a/Smeem-iOS/Smeem-iOS/Network/API/Auth/AuthAPI.swift
+++ b/Smeem-iOS/Smeem-iOS/Network/API/Auth/AuthAPI.swift
@@ -14,8 +14,8 @@ public class AuthAPI {
     private let authProvider = MoyaProvider<AuthService>(plugins: [MoyaLoggingPlugin()])
     private var betaTestResponse: BetaTestResponse?
     
-    func betaTestLoginAPI(completion: @escaping (GeneralResponse<BetaTestResponse>) -> Void) {
-        authProvider.request(.beta) { response in
+    func betaTestLoginAPI(param: BetaTestRequest, completion: @escaping (GeneralResponse<BetaTestResponse>) -> Void) {
+        authProvider.request(.beta(param: param)) { response in
             switch response {
             case .success(let result):
                 guard let token = try? result.map(GeneralResponse<BetaTestResponse>.self) else { return }

--- a/Smeem-iOS/Smeem-iOS/Network/API/Auth/AuthService.swift
+++ b/Smeem-iOS/Smeem-iOS/Network/API/Auth/AuthService.swift
@@ -9,7 +9,7 @@ import Foundation
 import Moya
 
 enum AuthService {
-    case beta
+    case beta(param: BetaTestRequest)
 }
 
 extension AuthService: TargetType {
@@ -26,7 +26,10 @@ extension AuthService: TargetType {
     }
     
     var task: Moya.Task {
-        return .requestJSONEncodable(UserDefaultsManager.fcmToken)
+        switch self {
+        case .beta(let param):
+            return .requestJSONEncodable(param)
+        }
     }
     
     var headers: [String : String]? {

--- a/Smeem-iOS/Smeem-iOS/Network/API/Auth/AuthService.swift
+++ b/Smeem-iOS/Smeem-iOS/Network/API/Auth/AuthService.swift
@@ -26,7 +26,7 @@ extension AuthService: TargetType {
     }
     
     var task: Moya.Task {
-        return .requestPlain
+        return .requestJSONEncodable(UserDefaultsManager.fcmToken)
     }
     
     var headers: [String : String]? {

--- a/Smeem-iOS/Smeem-iOS/Network/DataModel/MyPageInfoResponse.swift
+++ b/Smeem-iOS/Smeem-iOS/Network/DataModel/MyPageInfoResponse.swift
@@ -12,7 +12,7 @@ struct MyPageInfo: Codable {
     let targetLang: String
     var hasPushAlarm: Bool
     let trainingTime: TrainingTime
-    let badges: [Badge]
+    let badge: Badge
 }
 
 struct Badge: Codable {

--- a/Smeem-iOS/Smeem-iOS/Presentation/BottomSheet/Model/AuthModel.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/BottomSheet/Model/AuthModel.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+struct BetaTestRequest: Codable {
+    let fcmToken: String
+}
+
 struct BetaTestResponse: Codable {
     let accessToken: String
     let badges: [Badge]

--- a/Smeem-iOS/Smeem-iOS/Presentation/BottomSheet/Model/AuthModel.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/BottomSheet/Model/AuthModel.swift
@@ -9,4 +9,5 @@ import Foundation
 
 struct BetaTestResponse: Codable {
     let accessToken: String
+    let badges: [Badge]
 }

--- a/Smeem-iOS/Smeem-iOS/Presentation/BottomSheet/VC/BottomSheetViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/BottomSheet/VC/BottomSheetViewController.swift
@@ -101,7 +101,7 @@ final class BottomSheetViewController: UIViewController, LoginDelegate {
 
 extension BottomSheetViewController {
     private func betaLoginAPI() {
-        AuthAPI.shared.betaTestLoginAPI() { response in
+        AuthAPI.shared.betaTestLoginAPI(param: BetaTestRequest(fcmToken: UserDefaultsManager.fcmToken)) { response in
             guard let token = response.data?.accessToken else { return }
             UserDefaultsManager.betaLoginToken = token
             

--- a/Smeem-iOS/Smeem-iOS/Presentation/BottomSheet/VC/BottomSheetViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/BottomSheet/VC/BottomSheetViewController.swift
@@ -105,7 +105,6 @@ extension BottomSheetViewController {
             guard let token = response.data?.accessToken else { return }
             UserDefaultsManager.betaLoginToken = token
             
-            print(UserDefaultsManager.betaLoginToken, "값이 담긴 거야, 뭐야?")
             let userNicknameVC = UserNicknameViewController()
             userNicknameVC.userPlanRequest = self.userPlanRequest
             self.navigationController?.pushViewController(userNicknameVC, animated: true)

--- a/Smeem-iOS/Smeem-iOS/Presentation/BottomSheet/VC/BottomSheetViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/BottomSheet/VC/BottomSheetViewController.swift
@@ -17,6 +17,7 @@ final class BottomSheetViewController: UIViewController, LoginDelegate {
     var defaultSignUpHeight: CGFloat = 394
     
     var betaAccessToken = UserDefaultsManager.betaLoginToken
+    var popupBadgeData: [PopupBadge]?
     var userPlanRequest: UserPlanRequest?
     
     // MARK: - UI Property
@@ -102,11 +103,13 @@ final class BottomSheetViewController: UIViewController, LoginDelegate {
 extension BottomSheetViewController {
     private func betaLoginAPI() {
         AuthAPI.shared.betaTestLoginAPI(param: BetaTestRequest(fcmToken: UserDefaultsManager.fcmToken)) { response in
-            guard let token = response.data?.accessToken else { return }
-            UserDefaultsManager.betaLoginToken = token
+            guard let data = response.data else { return }
+            UserDefaultsManager.betaLoginToken = data.accessToken
+            self.popupBadgeData = [PopupBadge(name: data.badges[0].name, imageURL: data.badges[0].imageURL)]
             
             let userNicknameVC = UserNicknameViewController()
             userNicknameVC.userPlanRequest = self.userPlanRequest
+            userNicknameVC.badgeListData = self.popupBadgeData
             self.navigationController?.pushViewController(userNicknameVC, animated: true)
         }
     }

--- a/Smeem-iOS/Smeem-iOS/Presentation/Home/HomeViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Home/HomeViewController.swift
@@ -167,7 +167,6 @@ final class HomeViewController: UIViewController {
         setLayout()
         setDelegate()
         setSwipe()
-        print(UserDefaultsManager.betaLoginToken, "뭐암???")
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/Smeem-iOS/Smeem-iOS/Presentation/MyPage/MyPage/MyPageViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/MyPage/MyPage/MyPageViewController.swift
@@ -13,7 +13,7 @@ final class MyPageViewController: UIViewController {
     
     // MARK: - Property
     
-    private var userInfo = MyPageInfo(username: "", target: "", way: "", detail: "", targetLang: "", hasPushAlarm: true, trainingTime: TrainingTime(day: "", hour: 0, minute: 0), badges: [])
+    private var userInfo = MyPageInfo(username: "", target: "", way: "", detail: "", targetLang: "", hasPushAlarm: true, trainingTime: TrainingTime(day: "", hour: 0, minute: 0), badge: Badge(id: 0, name: "", type: "", imageURL: ""))
     
     // MARK: - UI Property
     
@@ -191,7 +191,8 @@ final class MyPageViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        isShownWelcomeBadgePopup()
+//        isShownWelcomeBadgePopup()
+        myPageInfoAPI()
     }
     
     // MARK: - @objc
@@ -235,23 +236,23 @@ final class MyPageViewController: UIViewController {
         
         howLearningView.setData(planName: userInfo.target, planWayOne: planWayOne, planWayTwo: planWayTwo, detailPlanOne: detailPlan[0], detailPlanTwo: detailPlan[1])
         nickNameLabel.text = userInfo.username
-        let url = URL(string: userInfo.badges[0].imageURL)
+        let url = URL(string: userInfo.badge.imageURL)
         badgeImage.kf.setImage(with: url)
-        badgeNameLabel.text = (userInfo.badges[0].name)
-        badgeSummaryLabel.text = "축하해요! \(userInfo.badges[0].name)를 획득했어요!"
+        badgeNameLabel.text = (userInfo.badge.name)
+        badgeSummaryLabel.text = "축하해요! \(userInfo.badge.name)를 획득했어요!"
     }
     
-    private func isShownWelcomeBadgePopup() {
-        let welcomeBadgePopup = UserDefaultsManager.isShownWelcomeBadgePopup
-
-        if !welcomeBadgePopup {
-            UserDefaultsManager.isShownWelcomeBadgePopup = true
-            let badgePopupVC = BadgePopupViewController()
-            badgePopupVC.modalTransitionStyle = .crossDissolve
-            badgePopupVC.modalPresentationStyle = .overFullScreen
-            self.present(badgePopupVC, animated: true)
-        }
-    }
+//    private func isShownWelcomeBadgePopup() {
+//        let welcomeBadgePopup = UserDefaultsManager.isShownWelcomeBadgePopup
+//
+//        if !welcomeBadgePopup {
+//            UserDefaultsManager.isShownWelcomeBadgePopup = true
+//            let badgePopupVC = BadgePopupViewController()
+//            badgePopupVC.modalTransitionStyle = .crossDissolve
+//            badgePopupVC.modalPresentationStyle = .overFullScreen
+//            self.present(badgePopupVC, animated: true)
+//        }
+//    }
     
     private func swipeRecognizer() {
         let swipeRight = UISwipeGestureRecognizer(target: self, action: #selector(responseToSwipeGesture))
@@ -410,8 +411,10 @@ final class MyPageViewController: UIViewController {
 extension MyPageViewController {
     func myPageInfoAPI() {
         MyPageAPI.shared.myPageInfo() { response in
+            print("오ㅔ 없냐구", response)
             guard let myPageInfo = response?.data else { return }
             self.userInfo = myPageInfo
+            print("오ㅔ 없냐구", myPageInfo)
             self.setData()
         }
     }

--- a/Smeem-iOS/Smeem-iOS/Presentation/MyPage/MyPage/MyPageViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/MyPage/MyPage/MyPageViewController.swift
@@ -411,10 +411,8 @@ final class MyPageViewController: UIViewController {
 extension MyPageViewController {
     func myPageInfoAPI() {
         MyPageAPI.shared.myPageInfo() { response in
-            print("오ㅔ 없냐구", response)
             guard let myPageInfo = response?.data else { return }
             self.userInfo = myPageInfo
-            print("오ㅔ 없냐구", myPageInfo)
             self.setData()
         }
     }

--- a/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Nickname/UserNickNameViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/Onboarding/Nickname/UserNickNameViewController.swift
@@ -13,6 +13,7 @@ final class UserNicknameViewController: UIViewController {
     
     var userPlanRequest: UserPlanRequest?
     var checkDouble = Bool()
+    var badgeListData: [PopupBadge]?
     
     // MARK: - UI Property
     
@@ -96,8 +97,9 @@ final class UserNicknameViewController: UIViewController {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
             if self.checkDouble {
-                let HomeVC = HomeViewController()
-                self.changeRootViewController(HomeVC)
+                let homeVC = HomeViewController()
+                homeVC.badgePopupData = self.badgeListData ?? []
+                self.changeRootViewController(homeVC)
             } else {
                 self.nextButton.smeemButtonType = .notEnabled
                 self.doubleCheckLabel.isHidden = false

--- a/Smeem-iOS/Smeem-iOS/Supports/AppDelegate.swift
+++ b/Smeem-iOS/Smeem-iOS/Supports/AppDelegate.swift
@@ -87,6 +87,7 @@ extension AppDelegate: MessagingDelegate {
             print("Error fetching FCM registration token: \(error)")
           } else if let token = token {
             print("FCM registration token: \(token)")
+              UserDefaultsManager.fcmToken = token
           }
         }
     }


### PR DESCRIPTION
##  작업한 내용
- 베타 테스트 로그인 API 수정사항에 맞게 웰컴 배지 팝업을 홈에 띄우고, FCM 토큰을 request body에 담았습니다.

## 관련 이슈

- Resolved: #98
