### PR TITLE
[Fix] #115 - 마이페이지 버튼 에셋 이름 수정

### DIFF
--- a/Smeem-iOS/Smeem-iOS/Global/Constants/Image.swift
+++ b/Smeem-iOS/Smeem-iOS/Global/Constants/Image.swift
@@ -25,7 +25,7 @@ extension Constant {
         static let icnMoreHoriz = UIImage(named: "icnMoreHoriz")
         static let icnMoreMono = UIImage(named: "icnMoreMono")
         static let icnCheckActive = UIImage(named: "icnCheckActive")
-        static let icnMyPage = UIImage(named: "icnMyPage")
+        static let icnMyPage = UIImage(named: "icnMypage")
         static let icnRightArrow = UIImage(named: "icnRightArrow")
         static let icnPencil = UIImage(named: "icnPencil")
         static let icnRefresh = UIImage(named: "icnRefresh")


### PR DESCRIPTION
##  작업한 내용
에셋 이름 잘못되어서 마이페이지 안나타나길래 수정해주었습니다.

##  PR Point
진짜 에셋 이름 한 철자만 수정했습니다.

## 관련 이슈

- Resolved: #115 
