### PR TITLE
[Chore] #122 - 플레이스 홀더

### DIFF
--- a/Smeem-iOS/Smeem-iOS/Global/Extensions/UITextView+.swift
+++ b/Smeem-iOS/Smeem-iOS/Global/Extensions/UITextView+.swift
@@ -42,7 +42,6 @@ extension UITextView {
     func configureDiaryTextView(topInset: CGFloat) {
         self.textContainerInset = .init(top: topInset, left: 18, bottom: 0, right: 18)
         self.font = .b4
-        self.textColor = .smeemBlack
         self.tintColor = .point
     }
 }

--- a/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryStrategies.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryStrategies.swift
@@ -14,8 +14,8 @@ final class ForeignDiaryStrategy: DiaryStrategy {
         button.setImage(Constant.Image.btnRandomSubjectInactive, for: .normal)
     }
     
-    func configurePlaceHolderLabel(_ label: UILabel) {
-        label.text = "일기를 작성해주세요."
+    func configurePlaceHolder(_ textView: UITextView) {
+        textView.text = "일기를 작성해주세요."
     }
     
     func configureToolTipView(_ imageView: UIImageView) {
@@ -50,8 +50,8 @@ final class StepOneKoreanDiaryStrategy: DiaryStrategy {
         button.setImage(Constant.Image.btnRandomSubjectInactive, for: .normal)
     }
     
-    func configurePlaceHolderLabel(_ label: UILabel) {
-        label.text = "완전한 문장으로 한국어 일기를 작성하면, 더욱 정확한\n힌트를 받을 수 있어요."
+    func configurePlaceHolder(_ textView: UITextView) {
+        textView.text = "완전한 문장으로 한국어 일기를 작성하면, 더욱 정확한\n힌트를 받을 수 있어요."
     }
     
     func configureToolTipView(_ imageView: UIImageView) {
@@ -88,8 +88,8 @@ final class StepTwoKoreanDiaryStrategy: DiaryStrategy {
         }
     }
     
-    func configurePlaceHolderLabel(_ label: UILabel) {
-        label.text = "일기를 작성해주세요."
+    func configurePlaceHolder(_ textView: UITextView) {
+        textView.text = "일기를 작성해주세요."
     }
     
     func configureToolTipView(_ imageView: UIImageView) {

--- a/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryStrategies.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryStrategies.swift
@@ -10,12 +10,16 @@ import UIKit
 // MARK: - ForeignDiaryStrategy
 
 final class ForeignDiaryStrategy: DiaryStrategy {
+    var textViewPlaceholder: String {
+        return "일기를 작성해주세요."
+    }
+    
     func configureRandomSubjectButtonImage(_ button: UIButton) {
         button.setImage(Constant.Image.btnRandomSubjectInactive, for: .normal)
     }
     
     func configurePlaceHolder(_ textView: UITextView) {
-        textView.text = "일기를 작성해주세요."
+        textView.text = textViewPlaceholder
     }
     
     func configureToolTipView(_ imageView: UIImageView) {
@@ -46,12 +50,16 @@ final class ForeignDiaryStrategy: DiaryStrategy {
 // MARK: - StepOneKoreanDiaryStrategy
 
 final class StepOneKoreanDiaryStrategy: DiaryStrategy {
+    var textViewPlaceholder: String {
+        return "완전한 문장으로 한국어 일기를 작성하면, 더욱 정확한\n힌트를 받을 수 있어요."
+    }
+    
     func configureRandomSubjectButtonImage(_ button: UIButton) {
         button.setImage(Constant.Image.btnRandomSubjectInactive, for: .normal)
     }
     
     func configurePlaceHolder(_ textView: UITextView) {
-        textView.text = "완전한 문장으로 한국어 일기를 작성하면, 더욱 정확한\n힌트를 받을 수 있어요."
+        textView.text = textViewPlaceholder
     }
     
     func configureToolTipView(_ imageView: UIImageView) {
@@ -82,6 +90,10 @@ final class StepOneKoreanDiaryStrategy: DiaryStrategy {
 // MARK: - StepTwoKoreanDiaryStrategy
 
 final class StepTwoKoreanDiaryStrategy: DiaryStrategy {
+    var textViewPlaceholder: String {
+        return "일기를 작성해주세요."
+    }
+    
     func configureRandomSubjectButtonImage(_ button: UIButton) {
         func configureRandomSubjectButtonImage(_ button: UIButton) {
             button.setImage(Constant.Image.btnRandomSubjectEnabled, for: .normal)
@@ -89,7 +101,7 @@ final class StepTwoKoreanDiaryStrategy: DiaryStrategy {
     }
     
     func configurePlaceHolder(_ textView: UITextView) {
-        textView.text = "일기를 작성해주세요."
+        textView.text = textViewPlaceholder
     }
     
     func configureToolTipView(_ imageView: UIImageView) {

--- a/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryViewController.swift
@@ -45,6 +45,8 @@ class DiaryViewController: UIViewController {
     var isKeyboardVisible: Bool = false
     var keyboardHeight: CGFloat = 0.0
     var rightButtonFlag = false
+    var isInitialInput = true
+    var textViewPlaceholder = "일기를 작성해주세요."
     
     // MARK: - UI Property
     
@@ -99,6 +101,7 @@ class DiaryViewController: UIViewController {
         textView.configureTypingAttributes()
         textView.textContentType = .init(rawValue: "ko-KR")
         textView.delegate = self
+        textView.selectedRange = NSRange(location: 0, length: 0)
         return textView
     }()
     
@@ -482,7 +485,17 @@ extension DiaryViewController: UITextViewDelegate {
     
     func textViewDidChange(_ textView: UITextView) {
         let isTextEmpty = textView.text.isEmpty
-        placeHolderLabel.isHidden = !isTextEmpty
+//        placeHolderLabel.isHidden = !isTextEmpty
+        
+        if textView.text.contains(textViewPlaceholder) {
+            textView.text = textView.text.replacingOccurrences(of: textViewPlaceholder, with: "")
+            textView.textColor = .smeemBlack
+        }
+        
+        if textView.text.isEmpty {
+            textView.text = textViewPlaceholder
+            textView.textColor = .gray400
+        }
         
         guard let strategy = diaryStrategy else {
             rightNavigationButton.setTitleColor(.gray300, for: .normal)
@@ -506,12 +519,29 @@ extension DiaryViewController: UITextViewDelegate {
         rightNavigationButton.setTitleColor(rightButtonFlag ? .point : .gray300, for: .normal)
     }
     
-    func textViewDidChangeSelection(_ textView: UITextView) {
-        let cursorPosition = textView.selectedTextRange?.end
-        if let cursorPosition = cursorPosition {
-            let caretPositionRect = textView.caretRect(for: cursorPosition)
-            textView.scrollRectToVisible(caretPositionRect, animated: true)
+//    func textViewDidChangeSelection(_ textView: UITextView) {
+//        let cursorPosition = textView.selectedTextRange?.end
+//        if let cursorPosition = cursorPosition {
+//            let caretPositionRect = textView.caretRect(for: cursorPosition)
+//            textView.scrollRectToVisible(caretPositionRect, animated: true)
+//        }
+//    }
+    
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        let currentText = textView.text ?? ""
+        let updatedText = (currentText as NSString).replacingCharacters(in: range, with: text)
+        
+        if updatedText.isEmpty {
+            textView.text = textViewPlaceholder
+            textView.textColor = .gray400
+            textView.selectedTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.beginningOfDocument)
+            return false
+        } else if textView.textColor == .gray400 && !text.isEmpty {
+            textView.text = nil
+            textView.textColor = .smeemBlack
         }
+        
+        return true
     }
 }
 

--- a/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryViewController.swift
@@ -101,6 +101,8 @@ class DiaryViewController: UIViewController {
         textView.configureTypingAttributes()
         textView.textContentType = .init(rawValue: "ko-KR")
         textView.delegate = self
+        textView.textColor = .gray400
+        textView.text = textViewPlaceholder
         textView.selectedRange = NSRange(location: 0, length: 0)
         return textView
     }()
@@ -111,6 +113,7 @@ class DiaryViewController: UIViewController {
         label.numberOfLines = 0
         label.font = .b4
         label.setTextWithLineHeight(lineHeight: 21)
+        label.isHidden = true
         return label
     }()
     
@@ -484,17 +487,14 @@ extension DiaryViewController {
 extension DiaryViewController: UITextViewDelegate {
     
     func textViewDidChange(_ textView: UITextView) {
-        let isTextEmpty = textView.text.isEmpty
-//        placeHolderLabel.isHidden = !isTextEmpty
+        let isTextEmpty = textView.text.isEmpty || textView.text == textViewPlaceholder
         
-        if textView.text.contains(textViewPlaceholder) {
-            textView.text = textView.text.replacingOccurrences(of: textViewPlaceholder, with: "")
-            textView.textColor = .smeemBlack
-        }
-        
-        if textView.text.isEmpty {
+        if isTextEmpty {
             textView.text = textViewPlaceholder
             textView.textColor = .gray400
+            textView.selectedTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.beginningOfDocument)
+        } else {
+            textView.textColor = .smeemBlack
         }
         
         guard let strategy = diaryStrategy else {
@@ -519,13 +519,11 @@ extension DiaryViewController: UITextViewDelegate {
         rightNavigationButton.setTitleColor(rightButtonFlag ? .point : .gray300, for: .normal)
     }
     
-//    func textViewDidChangeSelection(_ textView: UITextView) {
-//        let cursorPosition = textView.selectedTextRange?.end
-//        if let cursorPosition = cursorPosition {
-//            let caretPositionRect = textView.caretRect(for: cursorPosition)
-//            textView.scrollRectToVisible(caretPositionRect, animated: true)
-//        }
-//    }
+    func textViewDidChangeSelection(_ textView: UITextView) {
+        if textView.textColor == .gray400 {
+            textView.selectedTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.beginningOfDocument)
+        }
+    }
     
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         let currentText = textView.text ?? ""
@@ -540,7 +538,6 @@ extension DiaryViewController: UITextViewDelegate {
             textView.text = nil
             textView.textColor = .smeemBlack
         }
-        
         return true
     }
 }

--- a/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryViewController.swift
@@ -18,6 +18,8 @@ protocol DiaryStrategy {
     func configureLeftNavigationButton(_ button: UIButton)
     func configureRightNavigationButton(_ button: UIButton)
     func configureStepLabel(_ label: UILabel)
+    
+    var textViewPlaceholder: String { get }
 }
 
 class DiaryViewController: UIViewController {
@@ -46,7 +48,6 @@ class DiaryViewController: UIViewController {
     var keyboardHeight: CGFloat = 0.0
     var rightButtonFlag = false
     var isInitialInput = true
-    var textViewPlaceholder = "일기를 작성해주세요."
     
     // MARK: - UI Property
     
@@ -102,7 +103,7 @@ class DiaryViewController: UIViewController {
         textView.textContentType = .init(rawValue: "ko-KR")
         textView.delegate = self
         textView.textColor = .gray400
-        textView.text = textViewPlaceholder
+//        textView.text = textViewPlaceholder
         textView.selectedRange = NSRange(location: 0, length: 0)
         return textView
     }()
@@ -469,12 +470,11 @@ extension DiaryViewController {
 // MARK: - UITextViewDelegate
 
 extension DiaryViewController: UITextViewDelegate {
-    
     func textViewDidChange(_ textView: UITextView) {
-        let isTextEmpty = textView.text.isEmpty || textView.text == textViewPlaceholder
+        let isTextEmpty = textView.text.isEmpty || textView.text == diaryStrategy?.textViewPlaceholder
         
         if isTextEmpty {
-            textView.text = textViewPlaceholder
+            textView.text = diaryStrategy?.textViewPlaceholder
             textView.textColor = .gray400
             textView.selectedTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.beginningOfDocument)
         } else {
@@ -514,7 +514,7 @@ extension DiaryViewController: UITextViewDelegate {
         let updatedText = (currentText as NSString).replacingCharacters(in: range, with: text)
         
         if updatedText.isEmpty {
-            textView.text = textViewPlaceholder
+            textView.text = diaryStrategy?.textViewPlaceholder
             textView.textColor = .gray400
             textView.selectedTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.beginningOfDocument)
             return false

--- a/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryViewController.swift
@@ -11,7 +11,7 @@ import SnapKit
 
 protocol DiaryStrategy {
     func configureRandomSubjectButtonImage(_ button: UIButton)
-    func configurePlaceHolderLabel(_ label: UILabel)
+    func configurePlaceHolder(_ textView: UITextView)
     func configureToolTipView(_ imageView: UIImageView)
     func configureRandomSubjectButton(_ button: UIButton)
     func configureLanguageLabel(_ label: UILabel)
@@ -105,16 +105,6 @@ class DiaryViewController: UIViewController {
         textView.text = textViewPlaceholder
         textView.selectedRange = NSRange(location: 0, length: 0)
         return textView
-    }()
-    
-    let placeHolderLabel: UILabel = {
-        let label = UILabel()
-        label.textColor = .gray400
-        label.numberOfLines = 0
-        label.font = .b4
-        label.setTextWithLineHeight(lineHeight: 21)
-        label.isHidden = true
-        return label
     }()
     
     let bottomView: UIView = {
@@ -314,7 +304,7 @@ class DiaryViewController: UIViewController {
         }
         
         diaryStrategy?.configureRandomSubjectButton(randomSubjectButton)
-        diaryStrategy?.configurePlaceHolderLabel(placeHolderLabel)
+        diaryStrategy?.configurePlaceHolder(inputTextView)
         diaryStrategy?.configureRandomSubjectButton(randomSubjectButton)
         diaryStrategy?.configureLanguageLabel(languageLabel)
         diaryStrategy?.configureLeftNavigationButton(leftNavigationButton)
@@ -370,7 +360,6 @@ class DiaryViewController: UIViewController {
         view.addSubviews(navigationView, inputTextView, bottomView)
         navigationView.addSubviews(navibarContentStackView, stepLabel)
         navibarContentStackView.addArrangedSubviews(leftNavigationButton, languageLabel, rightNavigationButton)
-        inputTextView.addSubview(placeHolderLabel)
         bottomView.addSubviews(thinLine, randomSubjectButton)
         
         navigationView.snp.makeConstraints {
@@ -396,11 +385,6 @@ class DiaryViewController: UIViewController {
             $0.top.equalTo(navigationView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(bottomView.snp.top)
-        }
-        
-        placeHolderLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(convertByHeightRatio(20))
-            $0.leading.equalToSuperview().offset(convertByWidthRatio(21))
         }
         
         bottomView.snp.makeConstraints {

--- a/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryViewController.swift
@@ -503,8 +503,7 @@ extension DiaryViewController: UITextViewDelegate {
     
     func textViewDidChangeSelection(_ textView: UITextView) {
         if textView.textColor == .gray400 {
-//            textView.selectedTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.beginningOfDocument)
-            textView.selectedRange = NSRange(location: 0, length: 0)
+            textView.selectedTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.beginningOfDocument)
         }
     }
     
@@ -529,7 +528,6 @@ extension DiaryStrategy {
     func englishValidation(with text: String, in viewController: DiaryViewController) -> Bool {
         return viewController.inputTextView.text.getArrayAfterRegex(regex: "[a-zA-z]").count > 0
     }
-    
 }
 
 extension StepOneKoreanDiaryStrategy {

--- a/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryViewController.swift
+++ b/Smeem-iOS/Smeem-iOS/Presentation/ForeignDiary/DiaryViewController.swift
@@ -103,8 +103,6 @@ class DiaryViewController: UIViewController {
         textView.textContentType = .init(rawValue: "ko-KR")
         textView.delegate = self
         textView.textColor = .gray400
-//        textView.text = textViewPlaceholder
-        textView.selectedRange = NSRange(location: 0, length: 0)
         return textView
     }()
     
@@ -505,7 +503,8 @@ extension DiaryViewController: UITextViewDelegate {
     
     func textViewDidChangeSelection(_ textView: UITextView) {
         if textView.textColor == .gray400 {
-            textView.selectedTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.beginningOfDocument)
+//            textView.selectedTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.beginningOfDocument)
+            textView.selectedRange = NSRange(location: 0, length: 0)
         }
     }
     


### PR DESCRIPTION
##  작업한 내용
* UITextView에서 텍스트 대치 방식으로 플레이스 홀더 구현
* placeholderLabel 관련 코드 삭제

##  PR Point
텍스트뷰에서 텍스트가 변경될 때마다 textViewDidChange() 메서드를 활용해 텍스트뷰의 내용이 비어있거나 placeholder와 동일할 경우, placeholder를 회색으로 설정하고 커서를 맨 앞으로 이동시키도록 구현하였습니다.

그런데 유저가 직접 placeholder 텍스트를 터치 후 커서 위치를 변경하고, 그 상태에서 지우기 버튼을 누르면 placeholder 텍스트 자체가 삭제되는 이슈가 발생했습니다..

사용자가 커서 위치를 변경할 때마다 이 메서드가 호출되는 textViewDidChangeSelection()을 사용해서 현재 텍스트의 색상이 회색(placeholder 상태)인 경우에만 커서 위치를 강제로 맨 앞으로 이동시키도록 구현하여 해결했습니다.

## 스크린샷

|뷰|설명|
|------|---|
|  ![Simulator Screen Recording - iPhone 14 - 2023-08-30 at 11 57 03](https://github.com/Team-Smeme/Smeem-iOS/assets/97212841/db902b6f-7abe-45ce-aac0-c08b13882250)  |  각 일기작성 뷰에서 플레이스홀더  |

## 관련 이슈

- Resolved: #122 
